### PR TITLE
feat: add ChatGPT Codex Responses endpoint support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ All notable changes to this project are tracked here. Dates use UTC.
 
 - `substrate health` command with aggregated shim/world summaries plus upgraded
   `substrate shim doctor --json` payloads for support bundle collection.
+- Dedicated ChatGPT Codex `backend-api/codex/responses` transport handling in
+  the gateway, including stream-native sync/stream assembly, route-specific
+  request shaping, and Codex conformance fixtures.
 
 ### Docs
 
@@ -18,11 +21,17 @@ All notable changes to this project are tracked here. Dates use UTC.
   repair snippets safely, and where to find the manifest files.
 - Added replay crate module-level docs with a runnable selection example and
   documented the `substrate-common::prelude` for shared types and helpers.
+- Added Codex route/auth/conformance contract docs plus OAuth setup/testing
+  guidance for ChatGPT Codex integrated and standalone handoff behavior.
 
 ### Changed
 
 - Split the `substrate-trace` and `world-windows-wsl` crates into focused
   modules while preserving their public surfaces and platform guards.
+- ChatGPT Codex OAuth requests now resolve `ChatGPT-Account-ID` from the
+  selected Substrate or standalone auth context, preserve tool-call
+  continuations on the Responses route, and fail before upstream when Codex
+  identity cannot be resolved.
 
 ## [0.2.0-beta.1] - 2025-10-30
 

--- a/crates/gateway/docs/OAUTH_SETUP.md
+++ b/crates/gateway/docs/OAUTH_SETUP.md
@@ -137,6 +137,12 @@ For the Codex route, account resolution follows a strict order:
 
 The JWT claim path is bounded compatibility fallback only. It does not redefine ownership, and the gateway must fail before any upstream Codex request when neither explicit nor JWT-derived `account_id` can be resolved.
 
+Mode selection for the Codex route is explicit and happens at gateway bootstrap, not inside the provider fallback path. Current bootstrap may carry the effective `llm.gateway.mode` posture through `SUBSTRATE_LLM_GATEWAY_MODE=in_world|host_only`:
+
+- `in_world` selects the integrated Substrate-delivered auth source
+- `host_only` selects the standalone local compatibility source
+- integrated mode never falls back to `~/.codex/auth.json` when the Substrate handoff is missing or incomplete
+
 For maintenance purposes, keep the Codex auth owner line explicit:
 
 - integrated mode consumes Substrate-delivered auth context first

--- a/crates/gateway/docs/OAUTH_SETUP.md
+++ b/crates/gateway/docs/OAUTH_SETUP.md
@@ -129,6 +129,14 @@ For integrated ChatGPT Codex deployments, the gateway does not treat local token
 
 Standalone local token material, including `~/.substrate-gateway/oauth_tokens.json`, remains a compatibility path only. It is useful for gateway-local OAuth operation, but it must not be read as proof of the integrated Substrate-owned auth boundary.
 
+For the Codex route, account resolution follows a strict order:
+
+1. In integrated mode, use `SUBSTRATE_LLM_BACKEND_AUTH_CLI_CODEX_ACCOUNT_ID` first.
+2. If that field is absent, fall back to the `chatgpt_account_id` claim inside the same Substrate-delivered OAuth access token.
+3. In standalone mode, use explicit `account_id` from local Codex auth state first, then the same JWT fallback rule.
+
+The JWT claim path is bounded compatibility fallback only. It does not redefine ownership, and the gateway must fail before any upstream Codex request when neither explicit nor JWT-derived `account_id` can be resolved.
+
 ## HTTP Endpoints
 
 The gateway exposes these OAuth HTTP endpoints directly:

--- a/crates/gateway/docs/OAUTH_SETUP.md
+++ b/crates/gateway/docs/OAUTH_SETUP.md
@@ -123,6 +123,12 @@ Tokens are stored in JSON format at `~/.substrate-gateway/oauth_tokens.json`:
 
 File permissions are automatically set to `0600` (owner read/write only) for security.
 
+### ChatGPT Codex handoff note
+
+For integrated ChatGPT Codex deployments, the gateway does not treat local token files as the trust boundary for account identity. The authoritative handoff contract is documented in [`docs/contracts/chatgpt-codex-auth-handoff-contract.md`](contracts/chatgpt-codex-auth-handoff-contract.md).
+
+Standalone local token material, including `~/.substrate-gateway/oauth_tokens.json`, remains a compatibility path only. It is useful for gateway-local OAuth operation, but it must not be read as proof of the integrated Substrate-owned auth boundary.
+
 ## HTTP Endpoints
 
 The gateway exposes these OAuth HTTP endpoints directly:

--- a/crates/gateway/docs/OAUTH_SETUP.md
+++ b/crates/gateway/docs/OAUTH_SETUP.md
@@ -137,6 +137,36 @@ For the Codex route, account resolution follows a strict order:
 
 The JWT claim path is bounded compatibility fallback only. It does not redefine ownership, and the gateway must fail before any upstream Codex request when neither explicit nor JWT-derived `account_id` can be resolved.
 
+For maintenance purposes, keep the Codex auth owner line explicit:
+
+- integrated mode consumes Substrate-delivered auth context first
+- explicit `account_id` remains authoritative over JWT-derived fallback
+- JWT-derived account identity is bounded compatibility fallback only
+- unresolved account identity must fail before any upstream request is sent
+- integrated mode must not require direct reads of host-local auth files inside the gateway runtime
+
+Codex auth or route drift should be revalidated against:
+
+- [`chatgpt-codex-auth-handoff-contract.md`](contracts/chatgpt-codex-auth-handoff-contract.md)
+- [`chatgpt-codex-route-contract.md`](contracts/chatgpt-codex-route-contract.md)
+- [`chatgpt-codex-conformance-and-drift-guard.md`](contracts/chatgpt-codex-conformance-and-drift-guard.md)
+
+The maintenance evidence anchors for that revalidation are:
+
+- `crates/gateway/src/providers/openai.rs`
+- `crates/gateway/tests/openai_responses_conformance.rs`
+- `crates/gateway/tests/openai_shared_parity.rs`
+- `crates/gateway/src/server/openai_conformance_test_support.rs`
+- `crates/gateway/tests/fixtures/openai_responses/codex-*.json`
+- this guide and `docs/OAUTH_TESTING.md`
+
+Treat the Codex auth guidance as stale and reopen route-specific review when any of the following drift materially:
+
+- Substrate auth-bundle delivery posture, secret-channel semantics, or integrated owner-line assumptions change
+- auth field identifiers, `account_id` precedence rules, or JWT fallback constraints change
+- the Codex route header contract or pre-upstream auth failure posture changes
+- local OAuth or token-storage guidance starts implying integrated trust-boundary authority
+
 ## HTTP Endpoints
 
 The gateway exposes these OAuth HTTP endpoints directly:

--- a/crates/gateway/docs/OAUTH_TESTING.md
+++ b/crates/gateway/docs/OAUTH_TESTING.md
@@ -148,6 +148,35 @@ Route-boundary validation for Codex should check all three rules explicitly:
 
 Integrated-mode validation should also prove that canonical Substrate env handoff is sufficient on its own and does not require gateway-local reads of `~/.codex/auth.json` or other local auth files.
 
+Codex maintenance work should read the auth boundary together with the route and conformance contracts:
+
+- [`chatgpt-codex-auth-handoff-contract.md`](contracts/chatgpt-codex-auth-handoff-contract.md)
+- [`chatgpt-codex-route-contract.md`](contracts/chatgpt-codex-route-contract.md)
+- [`chatgpt-codex-conformance-and-drift-guard.md`](contracts/chatgpt-codex-conformance-and-drift-guard.md)
+
+The owned evidence anchors for deterministic Codex revalidation are:
+
+- `crates/gateway/tests/openai_responses_conformance.rs`
+- `crates/gateway/tests/openai_shared_parity.rs`
+- `crates/gateway/src/server/openai_conformance_test_support.rs`
+- `crates/gateway/tests/fixtures/openai_responses/codex-*.json`
+- `crates/gateway/src/providers/openai.rs`
+
+Maintenance checks should explicitly preserve these Codex-route truths:
+
+- integrated mode resolves `ChatGPT-Account-ID` from Substrate-delivered auth context first
+- explicit `account_id` remains authoritative over JWT fallback
+- unresolved account identity fails before any upstream call
+- integrated mode does not depend on gateway-local auth-file reads
+- standalone local auth state remains compatibility-only and must not be described as the integrated trust boundary
+
+Reopen Codex-route review when any of the following drift materially:
+
+- auth-handoff ownership, field identifiers, precedence rules, or bounded fallback behavior change
+- the Codex route compatibility matrix, semantic SSE assembly, or sync-drain failure posture changes
+- fixture namespaces or evidence anchors move in a way that makes deterministic revalidation ambiguous
+- normalized-core behavior changes in a way that invalidates Codex-route fixture expectations
+
 ## Using OAuth with Providers
 
 ### 1. Configure provider

--- a/crates/gateway/docs/OAUTH_TESTING.md
+++ b/crates/gateway/docs/OAUTH_TESTING.md
@@ -134,6 +134,12 @@ curl -X POST http://localhost:13456/api/oauth/tokens/delete \
   -d '{"provider_id": "anthropic-max"}'
 ```
 
+## ChatGPT Codex Handoff Boundary
+
+The Codex auth-handoff contract lives in [`docs/contracts/chatgpt-codex-auth-handoff-contract.md`](contracts/chatgpt-codex-auth-handoff-contract.md). For integrated Substrate-managed Codex runs, local OAuth artifacts such as `~/.substrate-gateway/oauth_tokens.json` are compatibility-only and do not define the account-id trust boundary.
+
+If you are validating standalone gateway-local behavior, local auth files remain part of the compatibility path, but the gateway must still resolve a concrete `account_id` before any upstream request is sent.
+
 ## Using OAuth with Providers
 
 ### 1. Configure provider
@@ -223,6 +229,7 @@ After successful authentication:
 2. ✅ Configure provider with `auth_type = "oauth"`
 3. ✅ **Phase 3 Complete**: Bearer token injection works automatically!
 4. ✅ OAuth HTTP endpoints remain available without the retired admin UI
+5. ✅ For Codex integrated mode, follow the auth-handoff contract instead of treating local token storage as authoritative
 
 ## Security Notes
 

--- a/crates/gateway/docs/OAUTH_TESTING.md
+++ b/crates/gateway/docs/OAUTH_TESTING.md
@@ -146,7 +146,13 @@ Route-boundary validation for Codex should check all three rules explicitly:
 2. JWT extraction from the OAuth access token is bounded fallback only when the explicit field for the selected mode is absent.
 3. If no concrete `account_id` can be resolved, the gateway returns the shared auth error envelope before any upstream Codex request is attempted.
 
-Integrated-mode validation should also prove that canonical Substrate env handoff is sufficient on its own and does not require gateway-local reads of `~/.codex/auth.json` or other local auth files.
+Integrated-mode validation should also prove that canonical Substrate handoff is sufficient on its own and does not require gateway-local reads of `~/.codex/auth.json` or other local auth files.
+
+Bootstrap validation for the Codex route should keep mode selection explicit:
+
+- `SUBSTRATE_LLM_GATEWAY_MODE=in_world` selects the integrated auth source
+- `SUBSTRATE_LLM_GATEWAY_MODE=host_only` selects the standalone local compatibility source
+- missing integrated handoff must fail as auth before upstream and must not downgrade into standalone local auth-file reads
 
 Codex maintenance work should read the auth boundary together with the route and conformance contracts:
 

--- a/crates/gateway/docs/OAUTH_TESTING.md
+++ b/crates/gateway/docs/OAUTH_TESTING.md
@@ -140,6 +140,14 @@ The Codex auth-handoff contract lives in [`docs/contracts/chatgpt-codex-auth-han
 
 If you are validating standalone gateway-local behavior, local auth files remain part of the compatibility path, but the gateway must still resolve a concrete `account_id` before any upstream request is sent.
 
+Route-boundary validation for Codex should check all three rules explicitly:
+
+1. Explicit `account_id` wins over any JWT-derived value in both integrated and standalone modes.
+2. JWT extraction from the OAuth access token is bounded fallback only when the explicit field for the selected mode is absent.
+3. If no concrete `account_id` can be resolved, the gateway returns the shared auth error envelope before any upstream Codex request is attempted.
+
+Integrated-mode validation should also prove that canonical Substrate env handoff is sufficient on its own and does not require gateway-local reads of `~/.codex/auth.json` or other local auth files.
+
 ## Using OAuth with Providers
 
 ### 1. Configure provider

--- a/crates/gateway/docs/adr/0008-expand-openai-side-support-via-chat-completions-and-responses.md
+++ b/crates/gateway/docs/adr/0008-expand-openai-side-support-via-chat-completions-and-responses.md
@@ -268,13 +268,15 @@ Every SSE `data:` payload MUST be a JSON object with a `type` string that matche
 
 #### Tool loop contract (responses)
 
-Tool continuation MUST be performed using `function_call_output` input items:
+Tool continuation MUST be performed using `function_call` plus `function_call_output` input items:
 
 1. Client sends a request.
 2. Gateway emits `function_call` output items (non-streaming: in `output`; streaming: via events).
-3. Client executes tools, then sends a follow-up `/v1/responses` request whose `input` appends one `function_call_output` item per tool call:
+3. Client executes tools, then sends a follow-up `/v1/responses` request whose `input` preserves the authoritative `function_call` item for each continued tool call and appends one `function_call_output` item per tool call:
+   - `function_call` MUST use the flat Responses shape: `{ "type": "function_call", "call_id": string, "name": string, "arguments": string }`.
    - `call_id` MUST match the tool call id emitted by the model.
    - `output` MUST be a string (the client is responsible for serializing structured outputs).
+4. Orphaned `function_call_output` items without authoritative prior `function_call` provenance MUST be rejected before any upstream call; the gateway MUST NOT synthesize placeholder tool names or `{}` arguments.
 
 ### Adapter Boundaries (Implementation Constraints)
 

--- a/crates/gateway/docs/adr/0010-route-chatgpt-codex-oauth-via-backend-api-codex-responses.md
+++ b/crates/gateway/docs/adr/0010-route-chatgpt-codex-oauth-via-backend-api-codex-responses.md
@@ -183,7 +183,7 @@ For Substrate-managed in-world deployment, `ChatGPT-Account-ID` MUST come from t
 Integrated-mode owner line:
 
 - Substrate owns policy-gated host credential reads, auth-state resolution, and host-to-world delivery for the auth material required by this route
-- the gateway consumes a resolved auth context for the selected ChatGPT Codex OAuth provider route
+- gateway bootstrap selects integrated versus standalone auth mode before provider construction, and the gateway consumes the selected auth context for the selected ChatGPT Codex OAuth provider route
 - the provider request builder injects `ChatGPT-Account-ID` from that resolved auth context; it does not define the authoritative ownership of account identity for integrated mode
 - integrated-mode account-id resolution order is:
   1. explicit `account_id` from the Substrate-delivered auth context

--- a/crates/gateway/docs/adr/0010-route-chatgpt-codex-oauth-via-backend-api-codex-responses.md
+++ b/crates/gateway/docs/adr/0010-route-chatgpt-codex-oauth-via-backend-api-codex-responses.md
@@ -112,7 +112,19 @@ Live streams emit a semantic Responses event flow including:
 - `response.output_item.done`
 - `response.completed`
 
-When reasoning is enabled and `include = ["reasoning.encrypted_content"]`, the stream also emits reasoning output items with encrypted payloads before the final answer item.
+For this ADR, reasoning is enabled on this route only when `reasoning.effort` is present and its
+value is not `"none"`.
+
+When reasoning is enabled and `include = ["reasoning.encrypted_content"]`, the stream also emits
+reasoning output items with encrypted payloads before the final answer item.
+
+`reasoning.summary` does not enable reasoning by itself on this route; it only refines upstream
+reasoning behavior when the enabled predicate above is already true.
+
+This `reasoning.summary` gate is a route-local gateway normalization and validation rule for the
+ChatGPT Codex transport. Official OpenAI Responses documentation grounds encrypted reasoning items
+and stateless `include = ["reasoning.encrypted_content"]` behavior, but does not by itself define
+this exact `reasoning.summary` predicate for this route.
 
 For this route, streamed tool-call argument assembly depends on the Responses function-call argument event family (`response.function_call_arguments.delta` / `response.function_call_arguments.done`) that the gateway already treats as part of the supported semantic event surface.
 
@@ -269,10 +281,18 @@ Remaining supported-control matrix for this route:
 
 - `reasoning.effort` is `pass`
   - allowed values: `none`, `minimal`, `low`, `medium`, `high`, `xhigh`
+  - route-local enabled predicate: reasoning is enabled only when this field is present and not
+    equal to `"none"`
   - any other value is `reject`
 - `reasoning.summary` is `pass`
   - allowed values: `auto`, `concise`, `detailed`, `none`
   - `none` means the gateway omits the upstream summary field rather than sending a non-standard value
+  - any non-`none` summary value is legal only when `reasoning.effort` is present and not equal to
+    `"none"`
+  - this enabled-gate for non-`none` summaries is a route-local gateway policy for the Codex route,
+    not a claimed public OpenAI Responses invariant
+  - `reasoning.summary` alone does not enable reasoning, reasoning-item assembly, or public
+    reasoning output on this route
   - any other value is `reject`
 - `parallel_tool_calls` is `pass`
   - allowed values: `true`, `false`
@@ -285,7 +305,16 @@ Remaining supported-control matrix for this route:
   - any other value is `reject`
 - `include` is `pass` with restriction
   - allowed values are `[]` and `["reasoning.encrypted_content"]`
+  - `["reasoning.encrypted_content"]` is legal only when `reasoning.effort` is present and not
+    equal to `"none"`
+  - `include = ["reasoning.encrypted_content"]` is the only predicate that intentionally requests
+    encrypted reasoning items on this route
   - any other include entry, duplicate entry, or mixed include set is `reject` unless a later route-specific ADR revalidates it
+- `stream_options` is `reject`
+  - no `stream_options` member is part of the verified-supported ChatGPT Codex subset for this route
+  - public Responses `stream_options.include_obfuscation` does not have a verified Codex-route equivalent with the same caller-visible semantics
+  - the gateway MUST reject `stream_options` on this route rather than silently stripping, ignoring, or degrading it
+  - future route-specific ADRs MAY widen this only by naming the accepted member(s), the preserved semantics, and the verification coverage
 
 `tool_choice` compatibility matrix for this route:
 
@@ -370,9 +399,25 @@ Specifically, it MUST assemble output from:
 - `response.output_text.done`
 - `response.function_call_arguments.delta`
 - `response.function_call_arguments.done`
-- reasoning items when intentionally requested
+- reasoning items only when `reasoning.effort` is present and not `"none"` and
+  `include = ["reasoning.encrypted_content"]`
 
 `response.completed` remains the terminal lifecycle event and usage source, but MUST NOT be assumed to contain the full assembled `output` payload.
+
+Route-local reasoning visibility rule:
+
+- encrypted reasoning items are internal transport state only on this route
+- the gateway MUST NOT convert encrypted reasoning items into public OpenAI-visible reasoning text,
+  public `thinking` blocks, public `message.content` parts, or public annotations on this route
+- `reasoning.summary` does not widen that visibility rule; it is request-shaping state only unless a
+  later route-specific ADR explicitly permits a public reasoning-summary surface
+
+Grounding note:
+
+- official OpenAI Responses docs validate encrypted reasoning items, stateless `store = false`
+  operation, and `include = ["reasoning.encrypted_content"]` as public API behavior
+- this ADR's stricter `reasoning.summary` acceptance predicate remains a route-local Codex transport
+  policy derived from gateway normalization goals and route verification scope
 
 ### 8. Keep public ingress surfaces thin over the normalized core
 
@@ -384,6 +429,61 @@ Public ingress does not change:
 
 All of them continue to normalize into the shared internal request model first.
 Only the provider-side upstream transport changes when the routed provider is ChatGPT Codex OAuth.
+
+## Contract-Ready Gap List
+
+This ADR is directionally correct, but it is not clean seam-extraction input until the remaining
+route-contract ownership work below is completed.
+
+- a dedicated gateway-owned canonical contract note under `crates/gateway/docs/foundation/` is
+  authored and linked from this ADR as the normative source for the ChatGPT Codex route's
+  stream/tool-loop behavior
+- that contract freezes the route-specific semantic-stream assembly rules, including the event
+  families that are authoritative for output assembly and the rule that `response.completed` is a
+  terminal lifecycle/usage event rather than the assembled-answer source of truth
+- that contract freezes the `function_call` / `function_call_output` continuation contract for this
+  route, including authoritative normalized provenance requirements for any synthesized
+  `function_call`
+- that contract states the route-specific reasoning visibility rule so encrypted/internal reasoning
+  remains non-public unless a later explicit decision widens exposure
+- that contract names the verification surfaces that own implementation proof for this route,
+  including the provider adapter, normalized models, and deterministic fixtures/regressions
+- a dedicated Substrate-owned auth-handoff contract note is authored and linked from this ADR as
+  the normative source for integrated-mode host preflight, host-to-world secret delivery, and
+  gateway consumption of ChatGPT Codex auth material
+- that auth-handoff contract freezes the integrated-mode handoff posture already selected by the
+  surrounding ADRs and standards:
+  - host-side Substrate credential preflight remains policy-gated and authoritative
+  - host-to-world delivery remains a secret-channel payload with an inherited one-time FD/pipe auth
+    bundle by default
+  - any env var used in this path is limited to non-secret pointer semantics such as the auth-bundle
+    FD number
+- that auth-handoff contract freezes the closed `cli:codex` auth field set and names the canonical
+  auth field identifiers carried through the handoff artifact:
+  - `SUBSTRATE_LLM_BACKEND_AUTH_CLI_CODEX_ACCOUNT_ID`
+  - `SUBSTRATE_LLM_BACKEND_AUTH_CLI_CODEX_ACCESS_TOKEN`
+- that auth-handoff contract freezes integrated-mode vs standalone-mode selection and the ownership
+  split for extraction, validation, delivery, and request injection, so the gateway consumes the
+  delivered auth material but does not become the owner of host credential reads or trust-boundary
+  decisions
+- that auth-handoff contract names the verification surfaces that prove the handoff boundary,
+  including host-side preparation, world/backend delivery, gateway auth-context resolution, and the
+  provider request builder that injects `ChatGPT-Account-ID`
+
+Downstream seam planning implication:
+
+- any seam planning pack that treats this ADR as implementation input MUST include explicit
+  responsibility to write, review, and finalize that dedicated route contract before implementation
+  slices that depend on Codex-route stream assembly, continuation synthesis, or reasoning-handling
+  behavior are considered ready
+- any seam planning pack that treats this ADR as implementation input MUST include explicit
+  responsibility to write, review, and finalize the dedicated auth-handoff contract before
+  implementation slices that depend on integrated-mode ChatGPT Codex auth delivery, account-id
+  resolution, or provider-header injection behavior are considered ready
+- seam extraction and slice planning MUST treat route-contract finalization as a required planning
+  deliverable, not as incidental cleanup during implementation or closeout
+- seam extraction and slice planning MUST treat auth-handoff-contract finalization as a required
+  planning deliverable, not as incidental cleanup during implementation or closeout
 
 ## Consequences
 
@@ -416,6 +516,20 @@ Negative:
 
 ## Verification Boundary
 
+Extractor-readiness prerequisite:
+
+- this ADR is not extractor-ready on its own until the dedicated foundation-level ChatGPT Codex
+  route contract described in the gap list above exists and is adopted as a named verification
+  surface
+- this ADR is not extractor-ready on its own until the dedicated Substrate-owned auth-handoff
+  contract described in the gap list above exists and is adopted as a named verification surface
+- downstream seam planning packs that consume this ADR MUST carry an explicit contract-definition
+  responsibility for writing and finalizing that route contract before implementation slices are
+  promoted
+- downstream seam planning packs that consume this ADR MUST carry an explicit contract-definition
+  responsibility for writing and finalizing that auth-handoff contract before implementation slices
+  are promoted
+
 This ADR is complete when:
 
 1. OAuth-backed ChatGPT Codex sync and streaming both target `/backend-api/codex/responses`
@@ -430,6 +544,12 @@ This ADR is complete when:
    - no caller-visible control is silently stripped or degraded on the Codex route without an explicit compatibility rule
    - public gateway image inputs remain supported on the Codex route through typed `message` items with upstream `image_url` content items
    - `reasoning.effort`, `reasoning.summary`, `parallel_tool_calls`, `text.format.type`, `text.verbosity`, and `include` follow the route-specific compatibility matrix and reject unverified values
+   - reasoning is enabled on this route only when `reasoning.effort` is present and not `"none"`
+   - non-`none` `reasoning.summary` is rejected unless reasoning is enabled on this route, as a
+     route-local Codex validation rule rather than a claimed public OpenAI Responses invariant
+   - `include = ["reasoning.encrypted_content"]` is rejected unless reasoning is enabled on this route
+   - encrypted reasoning items are assembled only under that exact predicate and never surface as public OpenAI-visible reasoning output on this route
+   - `stream_options` is rejected deterministically on the Codex route unless a later route-specific ADR explicitly adds a verified equivalent
    - flat function tool serialization
    - conversational turns on the Codex route serialize as typed `message` items rather than bare message objects
    - `function_call` + `function_call_output` continuation threading

--- a/crates/gateway/docs/adr/0010-route-chatgpt-codex-oauth-via-backend-api-codex-responses.md
+++ b/crates/gateway/docs/adr/0010-route-chatgpt-codex-oauth-via-backend-api-codex-responses.md
@@ -454,10 +454,10 @@ route-contract ownership work below is completed.
 - that auth-handoff contract freezes the integrated-mode handoff posture already selected by the
   surrounding ADRs and standards:
   - host-side Substrate credential preflight remains policy-gated and authoritative
-  - host-to-world delivery remains a secret-channel payload with an inherited one-time FD/pipe auth
-    bundle by default
-  - any env var used in this path is limited to non-secret pointer semantics such as the auth-bundle
-    FD number
+  - current v1 host-to-world delivery may place the closed `SUBSTRATE_LLM_BACKEND_AUTH_CLI_CODEX_*`
+    auth values directly in the in-world gateway/manager process environment
+  - the preferred additive direction remains a secret-channel payload with an inherited one-time
+    FD/pipe auth bundle so secret values do not live in the in-world process environment by default
 - that auth-handoff contract freezes the closed `cli:codex` auth field set and names the canonical
   auth field identifiers carried through the handoff artifact:
   - `SUBSTRATE_LLM_BACKEND_AUTH_CLI_CODEX_ACCOUNT_ID`

--- a/crates/gateway/docs/contracts/chatgpt-codex-auth-handoff-contract.md
+++ b/crates/gateway/docs/contracts/chatgpt-codex-auth-handoff-contract.md
@@ -22,11 +22,18 @@ This contract does not own:
 ## Integrated-Mode Owner Line
 
 - Substrate owns policy-gated host credential reads, auth-state validation, and host-to-world delivery for the ChatGPT Codex auth material required by this route.
-- The gateway consumes a resolved auth context for the selected ChatGPT Codex OAuth provider route; it does not become the owner of host credential reads or trust-boundary decisions.
+- The gateway bootstrap selects integrated versus standalone auth mode before provider construction; provider code consumes the selected auth source and does not become the owner of host credential reads or trust-boundary decisions.
 - Secret-bearing delivery remains an auth bundle or equivalent secret-channel payload. Any env var used in this path is limited to non-secret pointer semantics such as a bundle file descriptor or handle.
 - The canonical integrated-mode field identifiers are:
   - `SUBSTRATE_LLM_BACKEND_AUTH_CLI_CODEX_ACCOUNT_ID`
   - `SUBSTRATE_LLM_BACKEND_AUTH_CLI_CODEX_ACCESS_TOKEN`
+
+Runtime bootstrap note:
+
+- The effective `llm.gateway.mode` posture is applied outside the provider boundary.
+- Current gateway bootstrap may carry that posture via `SUBSTRATE_LLM_GATEWAY_MODE=in_world|host_only`.
+- `in_world` selects the integrated auth source for this route.
+- `host_only` selects the bounded standalone compatibility source for gateway-local operation.
 
 The gateway must treat those fields as the authoritative integrated-mode inputs for this route.
 
@@ -65,7 +72,7 @@ The selected mode determines which auth context is consulted first.
 - The provider request builder consumes resolved auth context and injects:
   - `Authorization: Bearer <access_token>`
   - `ChatGPT-Account-ID: <resolved account_id>`
-- The provider path remains a consumer of resolved auth context. It does not become the owner of auth-source selection.
+- The provider path remains a consumer of resolved auth context. Auth-source selection is explicit and external to the provider.
 - Provider code must not perform host-local auth-file reads for integrated mode.
 - A JWT-only helper may remain as an implementation detail for bounded fallback, but only behind the resolution order above.
 

--- a/crates/gateway/docs/contracts/chatgpt-codex-auth-handoff-contract.md
+++ b/crates/gateway/docs/contracts/chatgpt-codex-auth-handoff-contract.md
@@ -23,7 +23,9 @@ This contract does not own:
 
 - Substrate owns policy-gated host credential reads, auth-state validation, and host-to-world delivery for the ChatGPT Codex auth material required by this route.
 - The gateway bootstrap selects integrated versus standalone auth mode before provider construction; provider code consumes the selected auth source and does not become the owner of host credential reads or trust-boundary decisions.
-- Secret-bearing delivery remains an auth bundle or equivalent secret-channel payload. Any env var used in this path is limited to non-secret pointer semantics such as a bundle file descriptor or handle.
+- Current v1 integrated delivery may place secret-bearing values for the closed `SUBSTRATE_LLM_BACKEND_AUTH_CLI_CODEX_*` field set directly in the in-world gateway/manager process environment.
+- That v1 env-based delivery remains subordinate to the Substrate-owned trust boundary above: host credential reads stay policy-gated, values are not authoritative because they are in env vars, and the gateway remains only a consumer of the delivered auth context.
+- The preferred additive direction remains a secret-channel payload plus inherited FD/pipe-style auth-bundle delivery so secret values do not live in the in-world process environment by default.
 - The canonical integrated-mode field identifiers are:
   - `SUBSTRATE_LLM_BACKEND_AUTH_CLI_CODEX_ACCOUNT_ID`
   - `SUBSTRATE_LLM_BACKEND_AUTH_CLI_CODEX_ACCESS_TOKEN`
@@ -35,7 +37,7 @@ Runtime bootstrap note:
 - `in_world` selects the integrated auth source for this route.
 - `host_only` selects the bounded standalone compatibility source for gateway-local operation.
 
-The gateway must treat those fields as the authoritative integrated-mode inputs for this route.
+The gateway must treat those field names as the authoritative integrated-mode inputs for this route, whether the current runtime receives their values through v1 env delivery or a later auth-bundle carrier.
 
 ## Standalone Compatibility Mode
 

--- a/crates/gateway/docs/contracts/chatgpt-codex-auth-handoff-contract.md
+++ b/crates/gateway/docs/contracts/chatgpt-codex-auth-handoff-contract.md
@@ -1,0 +1,104 @@
+# ChatGPT Codex Auth Handoff Contract
+
+This document is the descriptive source of truth for the gateway's ChatGPT Codex auth-handoff boundary.
+It freezes how integrated and standalone modes deliver and resolve `account_id` plus access-token material for the Codex route without turning gateway-local persistence into the owner of host credentials.
+
+## Scope
+
+This contract covers:
+
+- the integrated-mode owner line between Substrate host preflight, secret delivery, and in-world gateway consumption
+- the bounded standalone compatibility path for local Codex auth material
+- the closed `cli:codex` auth field set the gateway consumes
+- account-id resolution order, explicit-over-JWT precedence, and the JWT claim path used only as bounded fallback
+- provider-side `ChatGPT-Account-ID` injection and pre-upstream failure posture
+
+This contract does not own:
+
+- the OAuth browser flow, token refresh UX, or provider registration details
+- the route compatibility matrix for `backend-api/codex/responses`
+- a generic redesign of gateway-wide token persistence outside this route-specific auth boundary
+
+## Integrated-Mode Owner Line
+
+- Substrate owns policy-gated host credential reads, auth-state validation, and host-to-world delivery for the ChatGPT Codex auth material required by this route.
+- The gateway consumes a resolved auth context for the selected ChatGPT Codex OAuth provider route; it does not become the owner of host credential reads or trust-boundary decisions.
+- Secret-bearing delivery remains an auth bundle or equivalent secret-channel payload. Any env var used in this path is limited to non-secret pointer semantics such as a bundle file descriptor or handle.
+- The canonical integrated-mode field identifiers are:
+  - `SUBSTRATE_LLM_BACKEND_AUTH_CLI_CODEX_ACCOUNT_ID`
+  - `SUBSTRATE_LLM_BACKEND_AUTH_CLI_CODEX_ACCESS_TOKEN`
+
+The gateway must treat those fields as the authoritative integrated-mode inputs for this route.
+
+## Standalone Compatibility Mode
+
+- Standalone mode exists only for gateway-local operation outside a Substrate-managed in-world deployment.
+- Standalone mode may resolve local Codex auth state, for example `~/.codex/auth.json` or an equivalent local auth-context carrier for the same Codex account.
+- The local gateway OAuth token store at `~/.substrate-gateway/oauth_tokens.json` may carry token material for local OAuth flows, but it is not authoritative account-id storage on its own because the current schema stores access and refresh tokens without a first-class `account_id`.
+- Standalone compatibility must remain subordinate to the integrated owner line above; it must not redefine who owns account identity in integrated deployment.
+
+## Resolution And Precedence Rules
+
+The selected mode determines which auth context is consulted first.
+
+### Integrated mode
+
+1. Use explicit `account_id` from the Substrate-delivered auth context.
+2. If explicit `account_id` is absent, use the JWT-derived fallback from the same Substrate-delivered OAuth access token.
+3. If neither source yields an account id, fail before the upstream call.
+
+### Standalone mode
+
+1. Use explicit `account_id` from local Codex auth state.
+2. If explicit `account_id` is absent, use the JWT-derived fallback from the same local OAuth access token represented by that auth state.
+3. If neither source yields an account id, fail before the upstream call.
+
+### Shared precedence constraints
+
+- Explicit `account_id` always wins over the JWT-derived value when both are present.
+- JWT extraction is compatibility fallback only. It does not define ownership.
+- The JWT fallback reads the `chatgpt_account_id` field inside the `https://api.openai.com/auth` object in the OAuth access token payload currently handled by the provider adapter.
+- Integrated mode must not require direct reads of `~/.codex/auth.json` or other host-local auth files inside the in-world gateway runtime.
+
+## Provider Consumption Contract
+
+- The provider request builder consumes resolved auth context and injects:
+  - `Authorization: Bearer <access_token>`
+  - `ChatGPT-Account-ID: <resolved account_id>`
+- The provider path remains a consumer of resolved auth context. It does not become the owner of auth-source selection.
+- Provider code must not perform host-local auth-file reads for integrated mode.
+- A JWT-only helper may remain as an implementation detail for bounded fallback, but only behind the resolution order above.
+
+## Failure Posture
+
+- If the selected mode cannot resolve any valid `account_id`, the gateway fails before the upstream call.
+- That failure uses the normal gateway auth error envelope rather than a transport retry or partial upstream attempt.
+- Route execution must not silently drop the `ChatGPT-Account-ID` header, substitute a guessed value, or defer the failure until the upstream request returns.
+
+## Verification Anchors
+
+Implementation and regression evidence for this contract should land against:
+
+- `crates/gateway/src/auth/token_store.rs`
+- `crates/gateway/src/auth/oauth.rs`
+- `crates/gateway/src/server/oauth_handlers.rs`
+- `crates/gateway/src/providers/openai.rs`
+- `crates/gateway/src/server/mod.rs`
+- `crates/gateway/docs/OAUTH_SETUP.md`
+- `crates/gateway/docs/OAUTH_TESTING.md`
+
+Required verification additions for this contract:
+
+- `crates/gateway/src/providers/openai.rs`
+  - `codex_oauth_request_builder_prefers_explicit_account_id_over_jwt_fallback`
+  - `codex_oauth_request_builder_uses_jwt_fallback_only_when_explicit_account_id_is_absent`
+  - `codex_oauth_request_builder_fails_before_upstream_when_account_id_is_unresolvable`
+- integration or handler coverage proving the integrated path does not require local auth-file reads to establish `ChatGPT-Account-ID`
+- documentation updates that distinguish standalone local OAuth/token material from the integrated Substrate-owned handoff boundary
+
+Verification passes only when:
+
+- explicit `account_id` wins whenever both explicit and JWT-derived values exist
+- JWT fallback is used only when the explicit field for the selected mode is absent
+- unresolved identity fails before any upstream request is sent and remains classified as an auth failure
+- integrated operation no longer depends on gateway-local token persistence or host-local auth files to establish `ChatGPT-Account-ID`

--- a/crates/gateway/docs/contracts/chatgpt-codex-conformance-and-drift-guard.md
+++ b/crates/gateway/docs/contracts/chatgpt-codex-conformance-and-drift-guard.md
@@ -1,0 +1,176 @@
+# ChatGPT Codex Conformance And Drift-Guard Contract
+
+This document is the descriptive source of truth for deterministic conformance and drift-guard obligations on the gateway's ChatGPT Codex route.
+It freezes the regression and maintenance contract for this route without redefining the upstream route behavior contract or the auth-handoff owner line.
+
+## Scope
+
+This contract covers:
+
+- deterministic sync and streaming conformance obligations for the ChatGPT Codex route
+- offline-first regression posture for route-local compatibility, semantic assembly, and auth provenance
+- the exact caller-visible behaviors that later verification must prove or reject explicitly
+- maintenance-facing revalidation triggers and evidence anchors for future route work
+
+This contract does not own:
+
+- redesign of public ingress behavior beyond the already-published route contract
+- changes to integrated-versus-standalone auth ownership beyond the already-published auth-handoff contract
+- live upstream probe automation as part of the core regression path
+- broad OpenAI compatibility expansion outside the verified Codex route subset
+
+## Contract Basis
+
+This contract depends on two previously published canonical contracts:
+
+- the route contract in `crates/gateway/docs/contracts/chatgpt-codex-route-contract.md`
+- the auth-handoff contract in `crates/gateway/docs/contracts/chatgpt-codex-auth-handoff-contract.md`
+
+The route contract remains the source of truth for:
+
+- the dedicated `https://chatgpt.com/backend-api/codex/responses` transport
+- the `pass | translate | force | reject` compatibility matrix
+- typed `message` shaping, flat function tool rules, continuation legality, semantic stream assembly, and sync-drain failure posture
+- the rule that encrypted reasoning remains non-public on this route
+
+The auth-handoff contract remains the source of truth for:
+
+- the integrated-mode owner line between Substrate delivery and gateway consumption
+- the bounded standalone compatibility path
+- explicit-over-JWT `account_id` precedence and pre-upstream failure behavior
+- the rule that integrated mode must not require host-local auth-file reads inside the gateway runtime
+
+This contract freezes downstream verification obligations against that published basis. It must not silently widen, narrow, or reinterpret either upstream contract.
+
+## Deterministic Suite Posture
+
+- The core drift-guard suite stays offline and deterministic wherever possible.
+- Fixture-backed and harness-backed verification is the default posture for this route.
+- Live upstream network dependence is not part of the core regression path.
+- Captured probe evidence may inform future refresh decisions, but the maintained suite should fail on local deterministic regressions before any live revalidation is needed.
+- Sync and streaming verification must derive from the same semantic upstream event model rather than from separate route-specific truths.
+
+## Route Conformance Obligations
+
+Later implementation and verification for this route must prove the following caller-visible obligations from the route contract:
+
+- later slices must implement the published route matrix exactly as frozen below rather than inferring it from current code shape alone
+
+### Forced controls
+
+The following controls remain fixed on this route:
+
+- `stream = true`
+- `store = false`
+- `text.format.type = "text"`
+
+### Translated controls
+
+The following caller-visible controls remain accepted only through the published translate behavior:
+
+- bare message objects become typed `message` items before upstream submission
+- supported image inputs become upstream `image_url` content parts, with optional `detail`
+- function tool definitions use the published flat shape for this route
+- explicit function `tool_choice` uses the published flat shape for this route
+- sync callers are satisfied through stream-drain execution over the same upstream SSE transport used by streaming callers
+
+### Passed controls
+
+The following controls remain passed through subject to the published route constraints:
+
+- `reasoning.effort` with values `none`, `minimal`, `low`, `medium`, `high`, `xhigh`
+- `reasoning.summary` with values `auto`, `concise`, `detailed`, `none` only when reasoning is enabled
+- `parallel_tool_calls`
+- `text.verbosity` with values `low`, `medium`, `high`
+- `include = []`
+- `include = ["reasoning.encrypted_content"]` only when reasoning is enabled
+- `tool_choice = "none"`
+- `tool_choice = "auto"`
+
+### Rejected controls
+
+The following controls remain explicit rejects on this route:
+
+- `max_output_tokens`
+- `metadata`
+- `truncation`
+- `previous_response_id`
+- `temperature`
+- `top_p`
+- `user`
+- unverified `service_tier` overrides
+- nested Chat Completions-style tool definitions
+- nested Chat Completions-style `tool_choice`
+- `tool_choice = "required"`
+- `stream_options`
+
+Unsupported caller-visible controls fail explicitly before the upstream call rather than being silently stripped, ignored, or degraded.
+
+### Additional route obligations
+
+- typed `message` shaping remains the canonical outbound message form
+- supported image input translation remains bounded to the published typed-message and `image_url` rules
+- function tools and explicit function `tool_choice` remain in the published flat shape for this route
+- continuation handling preserves the published legality, synthesis, and ordering rules for `function_call` and `function_call_output`
+- sync and streaming remain semantically aligned because they are derived from the same upstream SSE event family
+- sync-drain success still requires terminal `response.completed`, and malformed or truncated drains still fail with the published transport-drift posture
+- encrypted reasoning remains internal transport state and does not become public OpenAI-visible output on this route
+
+## Auth Provenance Obligations
+
+Later implementation and verification for this route must prove the following auth-source obligations from the auth-handoff contract:
+
+- integrated mode resolves `ChatGPT-Account-ID` from Substrate-delivered auth context first
+- explicit `account_id` remains authoritative over JWT-derived fallback when both exist
+- JWT-derived account identity remains bounded compatibility fallback only
+- unresolved account identity fails before the upstream call using the normal auth failure posture
+- integrated mode does not require gateway-local token persistence or host-local auth-file reads to establish `ChatGPT-Account-ID`
+- standalone local auth state remains compatibility-only and must not be treated as the integrated trust boundary
+- provider-side header injection remains a consumer of resolved auth context rather than the owner of auth-source selection
+
+## Verification Anchors
+
+Implementation and regression evidence for this contract should land against:
+
+- `crates/gateway/tests/openai_responses_conformance.rs`
+- `crates/gateway/tests/openai_shared_parity.rs`
+- `crates/gateway/src/server/openai_conformance_test_support.rs`
+- `crates/gateway/docs/openai-compatibility.md`
+- `crates/gateway/docs/OAUTH_SETUP.md`
+- `crates/gateway/docs/OAUTH_TESTING.md`
+
+The authoritative deterministic fixture family for this seam's route regressions is:
+
+- `crates/gateway/tests/fixtures/openai_responses/codex-*.json`
+
+Later slices should treat that Codex route fixture namespace as the owned fixture family for deterministic sync/stream route coverage, continuation ordering, and reject-vs-accept regression cases on this seam.
+
+Verification for this contract must make it possible for a maintainer to answer, without reverse-engineering implementation diffs:
+
+- which route controls are accepted, forced, translated, or rejected
+- which sync and streaming assertions prove semantic parity on this route
+- which assertions prove continuation legality and ordering
+- which assertions prove reasoning remains non-public
+- which assertions prove integrated auth provenance and bounded standalone fallback
+- which docs name the same stale triggers and evidence anchors that the regressions protect
+
+Later documentation alignment for this seam must land in:
+
+- `crates/gateway/docs/openai-compatibility.md`
+- `crates/gateway/docs/OAUTH_SETUP.md`
+- `crates/gateway/docs/OAUTH_TESTING.md`
+
+Those route-facing maintenance docs must mirror the same stale triggers and evidence anchors that the deterministic regressions protect, so future maintainers do not need to reconstruct drift conditions from code or planning artifacts alone.
+
+## Maintenance And Revalidation Triggers
+
+This contract should be treated as stale and reopened for review when any of the following change materially:
+
+- the route compatibility matrix or supported control classifications in the route contract
+- the semantic upstream event families, assembly rules, or sync-drain terminal requirements
+- the auth-handoff owner line, field identifiers, precedence rules, or fallback constraints
+- normalized-core behavior in a way that invalidates route-local fixture expectations
+- fixture namespaces, conformance harness behavior, or documentation anchors in a way that obscures what the route is proving
+- future route-specific controls are added or widened without explicit Codex-route revalidation
+
+Future maintenance should consume this contract as the route's drift-guard baseline rather than rediscovering obligations from scattered tests, implementation details, or ADR prose.

--- a/crates/gateway/docs/contracts/chatgpt-codex-route-contract.md
+++ b/crates/gateway/docs/contracts/chatgpt-codex-route-contract.md
@@ -1,0 +1,157 @@
+# ChatGPT Codex Route Contract
+
+This document is the descriptive source of truth for the gateway's ChatGPT Codex OAuth provider route.
+It freezes the provider-side transport contract described by ADR 0010 without leaking planning IDs into the canonical artifact.
+
+## Scope
+
+This contract covers:
+
+- the dedicated upstream endpoint for ChatGPT Codex OAuth traffic
+- the minimal successful header contract
+- the route-local `pass | translate | force | reject` compatibility matrix
+- typed `message` and image-part translation rules
+- flat function-tool and `tool_choice` rules
+- semantic stream assembly, continuation legality, and sync-drain failure posture
+- the rule that encrypted reasoning remains non-public on this route
+
+This contract does not own:
+
+- public ingress redesign for `/v1/messages`, `/v1/chat/completions`, or `/v1/responses`
+- integrated auth-handoff ownership beyond consuming a resolved `account_id` and access token
+- built-in tools, structured-output expansion, or unverified generic Responses fields
+
+## Transport Contract
+
+- Sync and streaming both target `https://chatgpt.com/backend-api/codex/responses`.
+- The gateway always sends `stream = true`.
+- The gateway always sends `store = false`.
+- Sync callers are satisfied by draining and assembling the upstream SSE stream into a `GatewayResponse`.
+- Streaming callers are satisfied by transforming the same upstream SSE stream into the normalized internal stream model.
+
+### Minimal Header Contract
+
+The only required outbound headers for this route are:
+
+- `Authorization: Bearer <access_token>`
+- `ChatGPT-Account-ID: <account_id>`
+- `Content-Type: application/json`
+
+The gateway omits `OpenAI-Beta`, `originator`, and browser-like parity headers on this route unless a later route-specific ADR revalidates them as required.
+
+## Compatibility Matrix
+
+### `force`
+
+- `stream = true`
+- `store = false`
+- `text.format.type = "text"`
+
+### `translate`
+
+- bare message objects are accepted at ingress but are translated into typed `message` items before upstream submission
+- supported image inputs are translated into upstream `image_url` content parts, with optional `detail`
+- flat function-tool definitions are emitted in the Codex wire shape
+- explicit function `tool_choice` is translated from the public OpenAI-side shape to the Codex-native flat shape
+- sync requests are translated into stream-drain execution over the same upstream SSE transport used by streaming requests
+
+### `pass`
+
+- `reasoning.effort` with values `none`, `minimal`, `low`, `medium`, `high`, `xhigh`
+- `reasoning.summary` with values `auto`, `concise`, `detailed`, `none`, subject to the reasoning-enabled predicate below
+- `parallel_tool_calls`
+- `text.verbosity` with values `low`, `medium`, `high`
+- `include` as either `[]` or `["reasoning.encrypted_content"]`, subject to the reasoning-enabled predicate below
+- `tool_choice = "none"`
+- `tool_choice = "auto"`
+
+### `reject`
+
+- `max_output_tokens`
+- `metadata`
+- `truncation`
+- `previous_response_id`
+- `temperature`
+- `top_p`
+- `user`
+- unverified `service_tier` overrides
+- nested Chat Completions-style tool definitions
+- nested Chat Completions-style `tool_choice`
+- `tool_choice = "required"`
+- `stream_options`
+
+Unsupported caller-visible controls fail before the upstream call. The route does not silently strip, ignore, or degrade them.
+
+## Message, Tool, And Continuation Rules
+
+- The canonical outbound form is a typed `message` item: `{ "type": "message", "role": "...", "content": [...] }`.
+- Supported image parts remain allowed only inside typed `message` items and become upstream `image_url` items.
+- Function tools use the flat Responses shape: `{ "type": "function", "name": "...", "description": "...", "parameters": { ... } }`.
+- Explicit function `tool_choice` uses the flat Codex shape: `{ "type": "function", "name": "..." }`.
+
+### Continuation Rules
+
+- Tool continuation uses flat Responses items:
+  - `function_call`
+  - `function_call_output`
+- `function_call_output.call_id` must match the model-emitted tool call id exactly.
+- A missing prior `function_call` may be synthesized only when the gateway already has authoritative normalized provenance for the same `call_id`.
+- When synthesis is allowed, the synthesized `function_call` copies `name` and serialized arguments from that authoritative provenance.
+- A synthesized `function_call` is inserted immediately before its matching `function_call_output`.
+- Orphaned tool-result continuations without authoritative provenance reject before the upstream call.
+- The gateway never emits duplicate `function_call` items for the same `call_id`.
+- Normalized conversation-history order remains the primary ordering key for mixed continuation requests.
+
+## Semantic Stream Assembly
+
+The event stream is the source of truth for assembled output on this route.
+
+The gateway assembles output from:
+
+- `response.output_item.added`
+- `response.output_item.done`
+- `response.content_part.added`
+- `response.content_part.done`
+- `response.output_text.delta`
+- `response.output_text.done`
+- `response.function_call_arguments.delta`
+- `response.function_call_arguments.done`
+
+`response.completed` is terminal lifecycle and usage truth. It is not the assembled-answer source of truth.
+
+### Sync-Drain Failure Rule
+
+- Sync success requires terminal `response.completed`.
+- If the upstream SSE stream is malformed, truncated, or terminates without `response.completed`, the gateway fails the sync call.
+- Sync-drain failures use the normal gateway error envelope with `class = "transport_drift"` and status `502`.
+
+## Reasoning Rules
+
+- Reasoning is enabled only when `reasoning.effort` is present and not equal to `"none"`.
+- Non-`none` `reasoning.summary` values are legal only when reasoning is enabled.
+- `include = ["reasoning.encrypted_content"]` is legal only when reasoning is enabled.
+- Encrypted reasoning items remain internal transport state.
+- The gateway does not surface encrypted reasoning as public OpenAI-visible text, public message content, or public reasoning summaries on this route.
+
+## Verification Anchors
+
+Implementation and regression evidence for this contract should land against:
+
+- `crates/gateway/src/providers/openai.rs`
+- `crates/gateway/src/providers/streaming.rs`
+- `crates/gateway/src/server/openai_responses.rs`
+- `crates/gateway/src/models/mod.rs`
+- `crates/gateway/tests/openai_responses_conformance.rs`
+- `crates/gateway/tests/openai_shared_parity.rs`
+
+Verification must prove:
+
+- sync/stream endpoint parity for Codex OAuth
+- minimal-header behavior
+- accepted versus rejected request controls
+- typed-message and image-part translation
+- flat tool and `tool_choice` shaping
+- semantic event assembly for text, tool, and mixed streams
+- deterministic continuation legality and ordering
+- `502 transport_drift` on malformed or truncated sync drains
+- non-public reasoning behavior on the route

--- a/crates/gateway/docs/contracts/chatgpt-codex-route-contract.md
+++ b/crates/gateway/docs/contracts/chatgpt-codex-route-contract.md
@@ -143,6 +143,7 @@ Implementation and regression evidence for this contract should land against:
 - `crates/gateway/src/models/mod.rs`
 - `crates/gateway/tests/openai_responses_conformance.rs`
 - `crates/gateway/tests/openai_shared_parity.rs`
+- `crates/gateway/tests/fixtures/openai_responses/codex-*.json`
 
 Verification must prove:
 

--- a/crates/gateway/docs/foundation/openai-side-responses-c11-contract.md
+++ b/crates/gateway/docs/foundation/openai-side-responses-c11-contract.md
@@ -49,6 +49,7 @@ The gateway accepts the following top-level fields:
 - `string` shorthand, which is treated as a single user `input_text`
 - `array` of items, with the following supported item types:
   - `message`
+  - `function_call`
   - `function_call_output`
 
 `message` items support:
@@ -61,9 +62,16 @@ The gateway accepts the following top-level fields:
 - `{ "type": "input_text", "text": string }`
 - `{ "type": "input_image", "image_url": string, "detail"?: "low"|"high"|"auto" }`
 
+`function_call` items support:
+
+- `{ "type": "function_call", "call_id": string, "name": string, "arguments": string }`
+- `call_id` and `name` MUST be non-empty strings.
+- `arguments` MUST be a string containing valid JSON.
+
 `function_call_output` items support:
 
 - `{ "type": "function_call_output", "call_id": string, "output": string }`
+- `function_call_output.call_id` MUST reference a prior `function_call` item for the same request.
 
 ## Tooling
 
@@ -88,9 +96,10 @@ Tool-loop continuation:
 
 1. Client sends a request.
 2. Gateway emits `function_call` output items.
-3. Client executes tools and appends one `function_call_output` item per tool call.
+3. Client executes tools and sends a follow-up request that preserves the authoritative prior `function_call` item and appends one `function_call_output` item per tool call.
 4. `function_call_output.call_id` MUST match the emitted tool id exactly.
 5. `function_call_output.output` MUST be a string.
+6. Orphaned `function_call_output` items reject before any upstream call; the gateway MUST NOT fabricate placeholder tool metadata.
 
 ## Ignore vs Reject Posture
 

--- a/crates/gateway/docs/foundation/openai-side-responses-c11-contract.md
+++ b/crates/gateway/docs/foundation/openai-side-responses-c11-contract.md
@@ -71,7 +71,7 @@ The gateway accepts the following top-level fields:
 `function_call_output` items support:
 
 - `{ "type": "function_call_output", "call_id": string, "output": string }`
-- `function_call_output.call_id` MUST reference a prior `function_call` item for the same request.
+- `function_call_output.call_id` MUST either reference a prior `function_call` item in the same request or be anchored by `previous_response_id` for a valid follow-up continuation request.
 
 ## Tooling
 
@@ -96,7 +96,9 @@ Tool-loop continuation:
 
 1. Client sends a request.
 2. Gateway emits `function_call` output items.
-3. Client executes tools and sends a follow-up request that preserves the authoritative prior `function_call` item and appends one `function_call_output` item per tool call.
+3. Client executes tools and sends a follow-up request that either:
+   - preserves the authoritative prior `function_call` item and appends one `function_call_output` item per tool call, or
+   - supplies `previous_response_id` and appends one `function_call_output` item per tool call without replaying the prior `function_call`.
 4. `function_call_output.call_id` MUST match the emitted tool id exactly.
 5. `function_call_output.output` MUST be a string.
 6. Orphaned `function_call_output` items reject before any upstream call; the gateway MUST NOT fabricate placeholder tool metadata.

--- a/crates/gateway/docs/openai-compatibility.md
+++ b/crates/gateway/docs/openai-compatibility.md
@@ -204,6 +204,25 @@ The route rejects these cases with `400`:
 
 JSON schema output, built-in tools, and non-function tool calls are not implemented on this public surface.
 
+### ChatGPT Codex route maintenance note
+
+This page describes the generic public `/v1/responses` surface. When that surface routes through the ChatGPT Codex OAuth backend, maintainers must revalidate against the Codex route contracts instead of assuming the generic route description applies unchanged.
+
+On the Codex route specifically:
+
+- `stream = true` is forced upstream
+- `store = false` is forced upstream
+- `text.format.type = "text"` is forced on the route
+- bare messages, supported image inputs, flat function tools, explicit function `tool_choice`, and sync-drain execution follow route-specific translate rules
+- `reasoning.effort`, `reasoning.summary`, `parallel_tool_calls`, `text.verbosity`, `include = []`, `include = ["reasoning.encrypted_content"]`, `tool_choice = "none"`, and `tool_choice = "auto"` are route-specific pass cases subject to the published constraints
+- `max_output_tokens`, `metadata`, `truncation`, `previous_response_id`, `temperature`, `top_p`, `user`, unverified `service_tier` overrides, nested Chat Completions-style tool definitions, nested Chat Completions-style `tool_choice`, `tool_choice = "required"`, and `stream_options` are explicit Codex-route rejects
+
+Codex route maintenance should use these canonical references:
+
+- [`chatgpt-codex-route-contract.md`](contracts/chatgpt-codex-route-contract.md)
+- [`chatgpt-codex-auth-handoff-contract.md`](contracts/chatgpt-codex-auth-handoff-contract.md)
+- [`chatgpt-codex-conformance-and-drift-guard.md`](contracts/chatgpt-codex-conformance-and-drift-guard.md)
+
 ### Minimal example
 
 ```json
@@ -232,6 +251,21 @@ Those tests cover, among other things:
 - `X-Provider` forcing
 - reasoning suppression
 - shared error-envelope behavior
+
+For ChatGPT Codex route maintenance, the owned deterministic evidence anchors are:
+
+- [gateway/tests/openai_responses_conformance.rs](../tests/openai_responses_conformance.rs)
+- [gateway/tests/openai_shared_parity.rs](../tests/openai_shared_parity.rs)
+- [gateway/src/server/openai_conformance_test_support.rs](../src/server/openai_conformance_test_support.rs)
+- `gateway/tests/fixtures/openai_responses/codex-*.json`
+
+Reopen Codex-route review when any of the following drift materially:
+
+- the Codex route compatibility matrix or supported-control classification changes
+- the semantic SSE event family, assembly rules, or sync-drain terminal requirements change
+- auth-handoff ownership, field identifiers, precedence rules, or fallback constraints change
+- normalized-core behavior changes in a way that invalidates Codex fixture expectations
+- fixture namespaces or maintenance-doc evidence anchors move in a way that obscures what the route is proving
 
 ## What Changed From The Old Doc
 

--- a/crates/gateway/docs/openai-compatibility.md
+++ b/crates/gateway/docs/openai-compatibility.md
@@ -151,6 +151,7 @@ Other rejected cases:
     - `data:` image URLs are also accepted
 - tool continuation input items:
   - `{ "type": "function_call_output", "call_id": "...", "output": "..." }`
+- `previous_response_id`
 - `tools`
   - function tools only
 - `tool_choice`
@@ -188,7 +189,7 @@ Other rejected cases:
   - `response.completed`
 - `response.completed` carries the final assembled Response object, including usage.
 - `parallel_tool_calls` is preserved into gateway metadata; it does not widen tool support beyond function tools.
-- Tool continuation uses `function_call_output` items and preserves `call_id`.
+- Tool continuation uses `function_call_output` items, preserves `call_id`, and accepts either replayed `function_call` history or `previous_response_id` as the continuation anchor.
 
 ### Rejected/unsupported behavior
 

--- a/crates/gateway/docs/project_management/packs/active/chatgpt-codex-oauth-backend-api-responses/README.md
+++ b/crates/gateway/docs/project_management/packs/active/chatgpt-codex-oauth-backend-api-responses/README.md
@@ -1,0 +1,36 @@
+# ChatGPT Codex OAuth Backend-API Responses - seam extraction
+
+Source: `docs/adr/0010-route-chatgpt-codex-oauth-via-backend-api-codex-responses.md`, `docs/IMPORTANT_SUBSTRATE_ALIGNMENT.md`, and current gateway OAuth/provider/auth surfaces under `crates/gateway/src/`
+
+This pack captures seam briefs, authoritative threading, pack-level review surfaces, seam-exit intent, and governance scaffolds. It is intentionally one level above seam-local decomposition.
+
+- Start here: `scope_brief.md`
+- Seam overview: `seam_map.md`
+- Threading: `threading.md`
+- Pack review surfaces: `review_surfaces.md`
+- Governance: `governance/remediation-log.md`
+
+Execution horizon:
+
+- Active seam: `SEAM-1`
+- Next seam: `SEAM-2`
+
+Policy:
+
+- only the active seam is eligible for authoritative downstream sub-slices by default
+- the next seam may later receive seam-local review + slices, and only provisional candidate-subslice hints
+- active and next seams must eventually terminate in a dedicated final `S99` `seam-exit-gate` slice once seam-local planning begins
+- seams that own undefined contracts may reserve `S00` as a contract-definition boundary slice once seam-local planning begins
+- `SEAM-3` remains a seam brief only until `SEAM-1` and `SEAM-2` publish route and auth truth
+- canonical contract docs are reserved under `docs/contracts/` for this pack and must remain descriptive-only
+
+Scope and assumptions restated before extraction:
+
+- the ADR's scope is to make ChatGPT Codex OAuth a dedicated upstream transport contract over `https://chatgpt.com/backend-api/codex/responses`, not a generic OpenAI Responses variant
+- the critical path is contract-first: the route contract and the Substrate-owned auth-handoff contract must become named verification surfaces before downstream implementation slices are considered ready
+- public ingress remains thin over the normalized core: `/v1/messages`, `/v1/chat/completions`, and `/v1/responses` stay public surfaces, while provider-side transport changes are isolated below them
+- the repo does not yet contain `crates/gateway/docs/contracts/`; this pack reserves descriptive canonical contract targets there without creating them yet
+
+Practical question this pack is intended to answer:
+
+- what exact seams must land so ChatGPT Codex OAuth requests can use the verified `backend-api/codex/responses` route with correct stream-native behavior, Substrate-compatible auth ownership, and deterministic drift guards

--- a/crates/gateway/docs/project_management/packs/active/chatgpt-codex-oauth-backend-api-responses/README.md
+++ b/crates/gateway/docs/project_management/packs/active/chatgpt-codex-oauth-backend-api-responses/README.md
@@ -12,18 +12,18 @@ This pack captures seam briefs, authoritative threading, pack-level review surfa
 
 Execution horizon:
 
-- Active seam: `SEAM-3`
-- Next seam: none yet
+- Active seam: none
+- Next seam: none
 
-`SEAM-1` and `SEAM-2` are landed and have moved out of the forward window. `SEAM-3` is now active because both route and auth ownership are published.
+`SEAM-1`, `SEAM-2`, and `SEAM-3` are landed and have moved out of the forward window. `THR-16` is now published as the maintenance-facing drift-guard baseline, and the pack currently has no active or next seam.
 
 Policy:
 
-- only the active seam is eligible for authoritative downstream sub-slices by default
-- the next seam may later receive seam-local review + slices, and only provisional candidate-subslice hints
+- no seam is currently eligible for authoritative downstream sub-slices because the forward planning window is empty
+- a future next seam may later receive seam-local review + slices, and only provisional candidate-subslice hints
 - active and next seams must eventually terminate in a dedicated final `S99` `seam-exit-gate` slice once seam-local planning begins
 - seams that own undefined contracts may reserve `S00` as a contract-definition boundary slice once seam-local planning begins
-- `SEAM-3` now owns the forward planning window because `THR-14` and `THR-15` are published and closeout-backed
+- future Codex-route maintenance should consume `THR-16` instead of reopening this pack's completed conformance seam
 - canonical contract docs are reserved under `crates/gateway/docs/contracts/` for this pack and must remain descriptive-only
 
 Scope and assumptions restated before extraction:

--- a/crates/gateway/docs/project_management/packs/active/chatgpt-codex-oauth-backend-api-responses/README.md
+++ b/crates/gateway/docs/project_management/packs/active/chatgpt-codex-oauth-backend-api-responses/README.md
@@ -12,8 +12,10 @@ This pack captures seam briefs, authoritative threading, pack-level review surfa
 
 Execution horizon:
 
-- Active seam: `SEAM-1`
-- Next seam: `SEAM-2`
+- Active seam: `SEAM-2`
+- Next seam: none yet
+
+`SEAM-1` is landed and has moved out of the forward window. `SEAM-3` remains future until `THR-15` is published.
 
 Policy:
 

--- a/crates/gateway/docs/project_management/packs/active/chatgpt-codex-oauth-backend-api-responses/README.md
+++ b/crates/gateway/docs/project_management/packs/active/chatgpt-codex-oauth-backend-api-responses/README.md
@@ -22,14 +22,14 @@ Policy:
 - active and next seams must eventually terminate in a dedicated final `S99` `seam-exit-gate` slice once seam-local planning begins
 - seams that own undefined contracts may reserve `S00` as a contract-definition boundary slice once seam-local planning begins
 - `SEAM-3` remains a seam brief only until `SEAM-1` and `SEAM-2` publish route and auth truth
-- canonical contract docs are reserved under `docs/contracts/` for this pack and must remain descriptive-only
+- canonical contract docs are reserved under `crates/gateway/docs/contracts/` for this pack and must remain descriptive-only
 
 Scope and assumptions restated before extraction:
 
 - the ADR's scope is to make ChatGPT Codex OAuth a dedicated upstream transport contract over `https://chatgpt.com/backend-api/codex/responses`, not a generic OpenAI Responses variant
 - the critical path is contract-first: the route contract and the Substrate-owned auth-handoff contract must become named verification surfaces before downstream implementation slices are considered ready
 - public ingress remains thin over the normalized core: `/v1/messages`, `/v1/chat/completions`, and `/v1/responses` stay public surfaces, while provider-side transport changes are isolated below them
-- the repo does not yet contain `crates/gateway/docs/contracts/`; this pack reserves descriptive canonical contract targets there without creating them yet
+- the repo now reserves descriptive canonical contract targets under `crates/gateway/docs/contracts/`, starting with the ChatGPT Codex route contract owned by `SEAM-1`
 
 Practical question this pack is intended to answer:
 

--- a/crates/gateway/docs/project_management/packs/active/chatgpt-codex-oauth-backend-api-responses/README.md
+++ b/crates/gateway/docs/project_management/packs/active/chatgpt-codex-oauth-backend-api-responses/README.md
@@ -12,10 +12,10 @@ This pack captures seam briefs, authoritative threading, pack-level review surfa
 
 Execution horizon:
 
-- Active seam: `SEAM-2`
+- Active seam: `SEAM-3`
 - Next seam: none yet
 
-`SEAM-1` is landed and has moved out of the forward window. `SEAM-3` remains future until `THR-15` is published.
+`SEAM-1` and `SEAM-2` are landed and have moved out of the forward window. `SEAM-3` is now active because both route and auth ownership are published.
 
 Policy:
 
@@ -23,7 +23,7 @@ Policy:
 - the next seam may later receive seam-local review + slices, and only provisional candidate-subslice hints
 - active and next seams must eventually terminate in a dedicated final `S99` `seam-exit-gate` slice once seam-local planning begins
 - seams that own undefined contracts may reserve `S00` as a contract-definition boundary slice once seam-local planning begins
-- `SEAM-3` remains a seam brief only until `SEAM-1` and `SEAM-2` publish route and auth truth
+- `SEAM-3` now owns the forward planning window because `THR-14` and `THR-15` are published and closeout-backed
 - canonical contract docs are reserved under `crates/gateway/docs/contracts/` for this pack and must remain descriptive-only
 
 Scope and assumptions restated before extraction:

--- a/crates/gateway/docs/project_management/packs/active/chatgpt-codex-oauth-backend-api-responses/governance/pack-closeout.md
+++ b/crates/gateway/docs/project_management/packs/active/chatgpt-codex-oauth-backend-api-responses/governance/pack-closeout.md
@@ -1,0 +1,19 @@
+# Pack Closeout - ChatGPT Codex OAuth Backend-API Responses
+
+- **Remaining open seams**:
+  - `SEAM-1`
+  - `SEAM-2`
+  - `SEAM-3`
+- **Open remediations still blocking pack closeout**:
+  - none recorded at extraction time
+- **Threads still not closed**:
+  - `THR-14`
+  - `THR-15`
+  - `THR-16`
+- **Downstream stale triggers still requiring attention**:
+  - live ChatGPT Codex route drift remains a reserved revalidation trigger until deterministic route evidence exists
+  - integrated auth-handoff ownership remains a reserved revalidation trigger until `C-15` publishes
+  - route-local conformance remains a reserved revalidation trigger until `C-16` publishes
+- **Evidence summary**:
+  - this pack is extracted from ADR 0010, `docs/IMPORTANT_SUBSTRATE_ALIGNMENT.md`, and current provider/auth/test surfaces under `crates/gateway/src/` and `crates/gateway/tests/`
+  - closeout remains pending until the three seam closeouts land and publish `C-14`, `C-15`, and `C-16`

--- a/crates/gateway/docs/project_management/packs/active/chatgpt-codex-oauth-backend-api-responses/governance/remediation-log.md
+++ b/crates/gateway/docs/project_management/packs/active/chatgpt-codex-oauth-backend-api-responses/governance/remediation-log.md
@@ -1,0 +1,34 @@
+# Remediation Log - ChatGPT Codex OAuth Backend-API Responses
+
+No remediations are opened during extraction by default. Risks and unknowns are captured in seam briefs and become remediations only when a pre-exec or post-exec gate raises a concrete issue.
+
+## Open remediations
+
+None.
+
+When a remediation is opened, append it here using the canonical schema:
+
+```yaml
+remediation_id: REM-<nnn>
+origin_phase: pre_exec | post_exec
+source_gate: review | contract | revalidation | landing | closeout
+related_seam: SEAM-<n> | null
+related_slice: null
+related_thread: THR-<nn> | null
+related_contract: C-<nn> | null
+related_artifact: <repo-relative-path> | null
+severity: blocking | material | follow_up
+status: open | in_progress | resolved | accepted_risk | carried_forward
+owner_seam: SEAM-<n>
+blocked_targets:
+  - seam: SEAM-<n>
+    field: status | execution_horizon
+    value: proposed | decomposed | exec-ready | in-flight | landed | closed | active | next | future
+summary: <one-sentence machine-readable finding summary>
+required_fix: <one-sentence explicit fix>
+resolution_evidence: []
+```
+
+## Resolved remediations
+
+Move resolved items here using the same schema with `status: resolved` and populated `resolution_evidence`.

--- a/crates/gateway/docs/project_management/packs/active/chatgpt-codex-oauth-backend-api-responses/governance/remediation-log.md
+++ b/crates/gateway/docs/project_management/packs/active/chatgpt-codex-oauth-backend-api-responses/governance/remediation-log.md
@@ -8,7 +8,7 @@ None.
 
 When a remediation is opened, append it here using the canonical schema:
 
-```yaml
+```text
 remediation_id: REM-<nnn>
 origin_phase: pre_exec | post_exec
 source_gate: review | contract | revalidation | landing | closeout

--- a/crates/gateway/docs/project_management/packs/active/chatgpt-codex-oauth-backend-api-responses/governance/remediation-log.md
+++ b/crates/gateway/docs/project_management/packs/active/chatgpt-codex-oauth-backend-api-responses/governance/remediation-log.md
@@ -4,27 +4,6 @@ No remediations are opened during extraction by default. Risks and unknowns are 
 
 ## Open remediations
 
-remediation_id: REM-001
-origin_phase: pre_exec
-source_gate: contract
-related_seam: SEAM-2
-related_slice: S00
-related_thread: THR-15
-related_contract: C-15
-related_artifact: crates/gateway/docs/project_management/packs/active/chatgpt-codex-oauth-backend-api-responses/threaded-seams/seam-2-substrate-auth-handoff-and-account-id-provenance/slice-00-freeze-auth-handoff-contract.md
-severity: blocking
-status: open
-owner_seam: SEAM-2
-blocked_targets:
-  - seam: SEAM-2
-    field: status
-    value: landed
-summary: The auth-handoff owner line is now fixed, but SEAM-2 still needs landed auth-context resolution, provider injection, and verification evidence before the contract can publish.
-required_fix: Land the S1/S2/S3 checklist so `crates/gateway/docs/contracts/chatgpt-codex-auth-handoff-contract.md`, resolved auth-context wiring, explicit-over-JWT precedence, and `THR-15` publication are all backed by code and verification evidence.
-resolution_evidence:
-  - crates/gateway/docs/contracts/chatgpt-codex-auth-handoff-contract.md
-  - crates/gateway/docs/project_management/packs/active/chatgpt-codex-oauth-backend-api-responses/threaded-seams/seam-2-substrate-auth-handoff-and-account-id-provenance/slice-00-freeze-auth-handoff-contract.md
-
 When a remediation is opened, append it here using the canonical schema:
 
 ```text
@@ -51,3 +30,30 @@ resolution_evidence: []
 ## Resolved remediations
 
 Move resolved items here using the same schema with `status: resolved` and populated `resolution_evidence`.
+
+```yaml
+remediation_id: REM-001
+origin_phase: pre_exec
+source_gate: contract
+related_seam: SEAM-2
+related_slice: S00
+related_thread: THR-15
+related_contract: C-15
+related_artifact: crates/gateway/docs/project_management/packs/active/chatgpt-codex-oauth-backend-api-responses/threaded-seams/seam-2-substrate-auth-handoff-and-account-id-provenance/slice-00-freeze-auth-handoff-contract.md
+severity: blocking
+status: resolved
+owner_seam: SEAM-2
+blocked_targets:
+  - seam: SEAM-2
+    field: status
+    value: landed
+summary: The auth-handoff owner line is now backed by landed auth-context resolution, provider injection, and closeout evidence, so the contract can publish and THR-15 can advance.
+required_fix: Land the S1/S2/S3 checklist so `crates/gateway/docs/contracts/chatgpt-codex-auth-handoff-contract.md`, resolved auth-context wiring, explicit-over-JWT precedence, and `THR-15` publication are all backed by code and verification evidence.
+resolution_evidence:
+  - crates/gateway/docs/contracts/chatgpt-codex-auth-handoff-contract.md
+  - crates/gateway/src/auth/codex_auth_context.rs
+  - crates/gateway/src/providers/openai.rs
+  - crates/gateway/docs/project_management/packs/active/chatgpt-codex-oauth-backend-api-responses/governance/seam-2-closeout.md
+  - crates/gateway/docs/OAUTH_SETUP.md
+  - crates/gateway/docs/OAUTH_TESTING.md
+```

--- a/crates/gateway/docs/project_management/packs/active/chatgpt-codex-oauth-backend-api-responses/governance/remediation-log.md
+++ b/crates/gateway/docs/project_management/packs/active/chatgpt-codex-oauth-backend-api-responses/governance/remediation-log.md
@@ -4,7 +4,24 @@ No remediations are opened during extraction by default. Risks and unknowns are 
 
 ## Open remediations
 
-None.
+remediation_id: REM-001
+origin_phase: pre_exec
+source_gate: contract
+related_seam: SEAM-2
+related_slice: S00
+related_thread: THR-15
+related_contract: C-15
+related_artifact: crates/gateway/docs/project_management/packs/active/chatgpt-codex-oauth-backend-api-responses/threaded-seams/seam-2-substrate-auth-handoff-and-account-id-provenance/review.md
+severity: blocking
+status: open
+owner_seam: SEAM-2
+blocked_targets:
+  - seam: SEAM-2
+    field: status
+    value: exec-ready
+summary: The owned auth-handoff contract baseline is not yet written into the canonical contract path, so SEAM-2 cannot become exec-ready.
+required_fix: Author docs/contracts/chatgpt-codex-auth-handoff-contract.md and mirror the owner line, field precedence, and fallback rules into the seam-local planning artifacts.
+resolution_evidence: []
 
 When a remediation is opened, append it here using the canonical schema:
 

--- a/crates/gateway/docs/project_management/packs/active/chatgpt-codex-oauth-backend-api-responses/governance/remediation-log.md
+++ b/crates/gateway/docs/project_management/packs/active/chatgpt-codex-oauth-backend-api-responses/governance/remediation-log.md
@@ -11,17 +11,19 @@ related_seam: SEAM-2
 related_slice: S00
 related_thread: THR-15
 related_contract: C-15
-related_artifact: crates/gateway/docs/project_management/packs/active/chatgpt-codex-oauth-backend-api-responses/threaded-seams/seam-2-substrate-auth-handoff-and-account-id-provenance/review.md
+related_artifact: crates/gateway/docs/project_management/packs/active/chatgpt-codex-oauth-backend-api-responses/threaded-seams/seam-2-substrate-auth-handoff-and-account-id-provenance/slice-00-freeze-auth-handoff-contract.md
 severity: blocking
 status: open
 owner_seam: SEAM-2
 blocked_targets:
   - seam: SEAM-2
     field: status
-    value: exec-ready
-summary: The owned auth-handoff contract baseline is not yet written into the canonical contract path, so SEAM-2 cannot become exec-ready.
-required_fix: Author docs/contracts/chatgpt-codex-auth-handoff-contract.md and mirror the owner line, field precedence, and fallback rules into the seam-local planning artifacts.
-resolution_evidence: []
+    value: landed
+summary: The auth-handoff owner line is now fixed, but SEAM-2 still needs landed auth-context resolution, provider injection, and verification evidence before the contract can publish.
+required_fix: Land the S1/S2/S3 checklist so `crates/gateway/docs/contracts/chatgpt-codex-auth-handoff-contract.md`, resolved auth-context wiring, explicit-over-JWT precedence, and `THR-15` publication are all backed by code and verification evidence.
+resolution_evidence:
+  - crates/gateway/docs/contracts/chatgpt-codex-auth-handoff-contract.md
+  - crates/gateway/docs/project_management/packs/active/chatgpt-codex-oauth-backend-api-responses/threaded-seams/seam-2-substrate-auth-handoff-and-account-id-provenance/slice-00-freeze-auth-handoff-contract.md
 
 When a remediation is opened, append it here using the canonical schema:
 

--- a/crates/gateway/docs/project_management/packs/active/chatgpt-codex-oauth-backend-api-responses/governance/seam-1-closeout.md
+++ b/crates/gateway/docs/project_management/packs/active/chatgpt-codex-oauth-backend-api-responses/governance/seam-1-closeout.md
@@ -1,0 +1,44 @@
+---
+seam_id: SEAM-1
+status: landed
+closeout_version: v0
+seam_exit_gate:
+  source_ref: docs/project_management/packs/active/chatgpt-codex-oauth-backend-api-responses/threaded-seams/seam-1-chatgpt-codex-route-contract-and-stream-native-transport/slice-99-seam-exit-gate.md
+  status: pending
+  promotion_readiness: blocked
+basis:
+  currentness: current
+  upstream_closeouts:
+    - docs/project_management/packs/active/openai-side-chat-completions-and-responses/governance/seam-2-closeout.md
+    - docs/project_management/packs/active/openai-side-chat-completions-and-responses/governance/seam-3-closeout.md
+  required_threads:
+    - THR-14
+  stale_triggers: []
+gates:
+  post_exec:
+    landing: pending
+    closeout: pending
+open_remediations: []
+---
+
+# Closeout - SEAM-1 ChatGPT Codex Route Contract And Stream-Native Transport
+
+## Seam-exit gate record
+
+- **Source artifact**: reserved future seam-exit slice at `threaded-seams/seam-1-chatgpt-codex-route-contract-and-stream-native-transport/slice-99-seam-exit-gate.md`
+- **Landed evidence**: pending implementation, contract publication, and deterministic route evidence
+- **Contracts published or changed**: pending `C-14`
+- **Threads published / advanced**: pending `THR-14`
+- **Review-surface delta**: pending post-exec comparison against `R1` and `R2`
+- **Planned-vs-landed delta**: not yet executed
+- **Downstream stale triggers raised**: none recorded yet
+- **Remediation disposition**: no post-exec remediation has been opened yet
+- **Promotion blockers**: route contract publication, provider implementation evidence, and closeout-backed seam-exit truth are all still missing
+- **Promotion readiness**: blocked
+
+## Post-exec gate disposition
+
+- **Landing gate**: pending
+- **Closeout gate**: pending
+- **Unresolved remediations**: none
+- **Carried-forward remediations**: none

--- a/crates/gateway/docs/project_management/packs/active/chatgpt-codex-oauth-backend-api-responses/governance/seam-1-closeout.md
+++ b/crates/gateway/docs/project_management/packs/active/chatgpt-codex-oauth-backend-api-responses/governance/seam-1-closeout.md
@@ -1,11 +1,11 @@
 ---
 seam_id: SEAM-1
 status: landed
-closeout_version: v0
+closeout_version: v1
 seam_exit_gate:
   source_ref: docs/project_management/packs/active/chatgpt-codex-oauth-backend-api-responses/threaded-seams/seam-1-chatgpt-codex-route-contract-and-stream-native-transport/slice-99-seam-exit-gate.md
-  status: pending
-  promotion_readiness: blocked
+  status: passed
+  promotion_readiness: ready
 basis:
   currentness: current
   upstream_closeouts:
@@ -13,11 +13,14 @@ basis:
     - docs/project_management/packs/active/openai-side-chat-completions-and-responses/governance/seam-3-closeout.md
   required_threads:
     - THR-14
-  stale_triggers: []
+  stale_triggers:
+    - the live ChatGPT Codex backend changes accepted fields, required headers, or semantic event ordering relative to the 2026-04-11 probe evidence captured in ADR 0010
+    - the normalized `GatewayRequest` or stream model changes in a way that invalidates the route-local compatibility matrix or continuation provenance assumptions
+    - public OpenAI-side contracts widen or tighten supported controls in a way that forces this route to reinterpret `pass`, `translate`, `force`, or `reject`
 gates:
   post_exec:
-    landing: pending
-    closeout: pending
+    landing: passed
+    closeout: passed
 open_remediations: []
 ---
 
@@ -25,20 +28,38 @@ open_remediations: []
 
 ## Seam-exit gate record
 
-- **Source artifact**: reserved future seam-exit slice at `threaded-seams/seam-1-chatgpt-codex-route-contract-and-stream-native-transport/slice-99-seam-exit-gate.md`
-- **Landed evidence**: pending implementation, contract publication, and deterministic route evidence
-- **Contracts published or changed**: pending `C-14`
-- **Threads published / advanced**: pending `THR-14`
-- **Review-surface delta**: pending post-exec comparison against `R1` and `R2`
-- **Planned-vs-landed delta**: not yet executed
-- **Downstream stale triggers raised**: none recorded yet
-- **Remediation disposition**: no post-exec remediation has been opened yet
-- **Promotion blockers**: route contract publication, provider implementation evidence, and closeout-backed seam-exit truth are all still missing
-- **Promotion readiness**: blocked
+- **Source artifact**: `threaded-seams/seam-1-chatgpt-codex-route-contract-and-stream-native-transport/slice-99-seam-exit-gate.md`
+- **Landed evidence**:
+  - canonical contract: `crates/gateway/docs/contracts/chatgpt-codex-route-contract.md` (`C-14`)
+  - code:
+    - `crates/gateway/src/providers/openai.rs`
+    - `crates/gateway/src/providers/streaming.rs`
+    - `crates/gateway/src/server/openai_responses.rs`
+    - `crates/gateway/src/models/mod.rs`
+  - regression coverage:
+    - `crates/gateway/tests/openai_responses_conformance.rs`
+    - `crates/gateway/tests/openai_shared_parity.rs`
+    - `crates/gateway/tests/fixtures/openai_responses/codex-*.json`
+  - commits:
+    - `e7fd6375` (`S1`)
+    - `e3fc547f` (`S2`)
+    - `e5c1ca45` (`S3`)
+- **Contracts published or changed**: `C-14` published
+- **Threads published / advanced**:
+  - `THR-14`: `published`
+- **Review-surface delta**: `R1` and `R2` now anchor on the landed Codex route contract, single `/backend-api/codex/responses` transport, minimal headers, and semantic stream assembly; `R3` remains the seam-2 auth boundary reference and now clearly shows the consumed route contract as published basis.
+- **Planned-vs-landed delta**: the planned endpoint parity, minimal-header contract, semantic event authority, sync-drain failure posture, and reasoning-visibility rule landed without scope expansion.
+- **Downstream stale triggers raised**:
+  - live ChatGPT Codex route drift remains a reserved revalidation trigger until the route contract is refreshed
+  - normalized request or stream-model changes that alter compatibility classification or continuation provenance require `C-14` refresh
+  - upstream supported-control changes that affect `pass`, `translate`, `force`, or `reject` require downstream revalidation
+- **Remediation disposition**: none opened
+- **Promotion blockers**: none
+- **Promotion readiness**: ready
 
 ## Post-exec gate disposition
 
-- **Landing gate**: pending
-- **Closeout gate**: pending
+- **Landing gate**: passed
+- **Closeout gate**: passed
 - **Unresolved remediations**: none
 - **Carried-forward remediations**: none

--- a/crates/gateway/docs/project_management/packs/active/chatgpt-codex-oauth-backend-api-responses/governance/seam-2-closeout.md
+++ b/crates/gateway/docs/project_management/packs/active/chatgpt-codex-oauth-backend-api-responses/governance/seam-2-closeout.md
@@ -1,0 +1,44 @@
+---
+seam_id: SEAM-2
+status: landed
+closeout_version: v0
+seam_exit_gate:
+  source_ref: docs/project_management/packs/active/chatgpt-codex-oauth-backend-api-responses/threaded-seams/seam-2-substrate-auth-handoff-and-account-id-provenance/slice-99-seam-exit-gate.md
+  status: pending
+  promotion_readiness: blocked
+basis:
+  currentness: current
+  upstream_closeouts:
+    - governance/seam-1-closeout.md
+  required_threads:
+    - THR-14
+    - THR-15
+  stale_triggers: []
+gates:
+  post_exec:
+    landing: pending
+    closeout: pending
+open_remediations: []
+---
+
+# Closeout - SEAM-2 Substrate Auth Handoff And Account-Id Provenance
+
+## Seam-exit gate record
+
+- **Source artifact**: reserved future seam-exit slice at `threaded-seams/seam-2-substrate-auth-handoff-and-account-id-provenance/slice-99-seam-exit-gate.md`
+- **Landed evidence**: pending auth-handoff contract publication, gateway consumption proof, and integrated-versus-standalone verification evidence
+- **Contracts published or changed**: pending `C-15`
+- **Threads published / advanced**: pending `THR-15`
+- **Review-surface delta**: pending post-exec comparison against `R3`
+- **Planned-vs-landed delta**: not yet executed
+- **Downstream stale triggers raised**: none recorded yet
+- **Remediation disposition**: no post-exec remediation has been opened yet
+- **Promotion blockers**: auth-handoff contract truth, provider injection evidence, and closeout-backed seam-exit truth are all still missing
+- **Promotion readiness**: blocked
+
+## Post-exec gate disposition
+
+- **Landing gate**: pending
+- **Closeout gate**: pending
+- **Unresolved remediations**: none
+- **Carried-forward remediations**: none

--- a/crates/gateway/docs/project_management/packs/active/chatgpt-codex-oauth-backend-api-responses/governance/seam-2-closeout.md
+++ b/crates/gateway/docs/project_management/packs/active/chatgpt-codex-oauth-backend-api-responses/governance/seam-2-closeout.md
@@ -1,11 +1,11 @@
 ---
 seam_id: SEAM-2
 status: landed
-closeout_version: v0
+closeout_version: v1
 seam_exit_gate:
   source_ref: docs/project_management/packs/active/chatgpt-codex-oauth-backend-api-responses/threaded-seams/seam-2-substrate-auth-handoff-and-account-id-provenance/slice-99-seam-exit-gate.md
-  status: pending
-  promotion_readiness: blocked
+  status: passed
+  promotion_readiness: ready
 basis:
   currentness: current
   upstream_closeouts:
@@ -13,11 +13,14 @@ basis:
   required_threads:
     - THR-14
     - THR-15
-  stale_triggers: []
+  stale_triggers:
+    - the auth-handoff owner line changes after S99 records closeout truth
+    - Substrate delivery posture or secret-channel semantics change for the Codex auth bundle
+    - the closed `cli:codex` field set or JWT fallback rule changes after the canonical auth-handoff contract is recorded
 gates:
   post_exec:
-    landing: pending
-    closeout: pending
+    landing: passed
+    closeout: passed
 open_remediations: []
 ---
 
@@ -25,20 +28,41 @@ open_remediations: []
 
 ## Seam-exit gate record
 
-- **Source artifact**: reserved future seam-exit slice at `threaded-seams/seam-2-substrate-auth-handoff-and-account-id-provenance/slice-99-seam-exit-gate.md`
-- **Landed evidence**: pending auth-handoff contract publication, gateway consumption proof, and integrated-versus-standalone verification evidence
-- **Contracts published or changed**: pending `C-15`
-- **Threads published / advanced**: pending `THR-15`
-- **Review-surface delta**: pending post-exec comparison against `R3`
-- **Planned-vs-landed delta**: not yet executed
-- **Downstream stale triggers raised**: none recorded yet
-- **Remediation disposition**: no post-exec remediation has been opened yet
-- **Promotion blockers**: auth-handoff contract truth, provider injection evidence, and closeout-backed seam-exit truth are all still missing
-- **Promotion readiness**: blocked
+- **Source artifact**: landed seam-exit slice at `threaded-seams/seam-2-substrate-auth-handoff-and-account-id-provenance/slice-99-seam-exit-gate.md`
+- **Landed evidence**:
+  - Canonical contract:
+    - `crates/gateway/docs/contracts/chatgpt-codex-auth-handoff-contract.md` (`C-15`)
+  - Auth-context resolution and owner-line tests:
+    - `crates/gateway/src/auth/codex_auth_context.rs`
+    - `integrated_mode_uses_substrate_account_id_first`
+    - `integrated_mode_uses_jwt_fallback_when_explicit_account_id_is_absent`
+    - `standalone_mode_uses_explicit_account_id_first`
+    - `standalone_mode_uses_jwt_fallback_when_explicit_account_id_is_absent`
+    - `auth_context_resolution_fails_when_account_id_is_unresolvable`
+  - Provider injection proof:
+    - `crates/gateway/src/providers/openai.rs`
+    - `codex_oauth_request_builder_emits_only_the_minimal_header_contract`
+  - Documentation evidence:
+    - `crates/gateway/docs/OAUTH_SETUP.md`
+    - `crates/gateway/docs/OAUTH_TESTING.md`
+  - Closeout basis and thread registry:
+    - `threading.md`
+    - `review.md`
+    - `governance/seam-2-closeout.md`
+- **Contracts published or changed**: `C-15` is recorded as the canonical auth-handoff contract; no new contract text changed in S99
+- **Threads published / advanced**: `THR-15` published
+- **Review-surface delta**: `R3` now has closeout-backed evidence for integrated-mode auth ownership, bounded JWT fallback, and provider-side `ChatGPT-Account-ID` injection without expanding the provider trust boundary
+- **Planned-vs-landed delta**: planned closeout truth required evidence that integrated mode consumes Substrate-delivered auth context first, fallback remains bounded, unresolved identity fails before upstream, and `THR-15` is published; landed evidence now confirms those assertions
+- **Downstream stale triggers raised**:
+  - `THR-15` or `C-15` changes after this closeout would require revalidation in `SEAM-3`
+  - any later change to Substrate auth-bundle delivery, secret-channel semantics, or the `cli:codex` field set would stale this closeout
+- **Remediation disposition**: `REM-001` is resolved by the landed S1/S2/S3 evidence plus this closeout record; no new remediation was opened by S99
+- **Promotion blockers**: none
+- **Promotion readiness**: ready
 
 ## Post-exec gate disposition
 
-- **Landing gate**: pending
-- **Closeout gate**: pending
+- **Landing gate**: passed
+- **Closeout gate**: passed
 - **Unresolved remediations**: none
 - **Carried-forward remediations**: none

--- a/crates/gateway/docs/project_management/packs/active/chatgpt-codex-oauth-backend-api-responses/governance/seam-3-closeout.md
+++ b/crates/gateway/docs/project_management/packs/active/chatgpt-codex-oauth-backend-api-responses/governance/seam-3-closeout.md
@@ -1,0 +1,46 @@
+---
+seam_id: SEAM-3
+status: landed
+closeout_version: v0
+seam_exit_gate:
+  source_ref: docs/project_management/packs/active/chatgpt-codex-oauth-backend-api-responses/threaded-seams/seam-3-codex-route-conformance-and-drift-guards/slice-99-seam-exit-gate.md
+  status: pending
+  promotion_readiness: blocked
+basis:
+  currentness: current
+  upstream_closeouts:
+    - governance/seam-1-closeout.md
+    - governance/seam-2-closeout.md
+  required_threads:
+    - THR-14
+    - THR-15
+    - THR-16
+  stale_triggers: []
+gates:
+  post_exec:
+    landing: pending
+    closeout: pending
+open_remediations: []
+---
+
+# Closeout - SEAM-3 Codex Route Conformance And Drift Guards
+
+## Seam-exit gate record
+
+- **Source artifact**: reserved future seam-exit slice at `threaded-seams/seam-3-codex-route-conformance-and-drift-guards/slice-99-seam-exit-gate.md`
+- **Landed evidence**: pending deterministic fixture coverage, auth-source regressions, and route-maintenance documentation updates
+- **Contracts published or changed**: pending `C-16`
+- **Threads published / advanced**: pending `THR-16`
+- **Review-surface delta**: pending post-exec comparison against `R1`, `R2`, and `R3`
+- **Planned-vs-landed delta**: not yet executed
+- **Downstream stale triggers raised**: none recorded yet
+- **Remediation disposition**: no post-exec remediation has been opened yet
+- **Promotion blockers**: conformance contract publication, deterministic evidence, and closeout-backed seam-exit truth are all still missing
+- **Promotion readiness**: blocked
+
+## Post-exec gate disposition
+
+- **Landing gate**: pending
+- **Closeout gate**: pending
+- **Unresolved remediations**: none
+- **Carried-forward remediations**: none

--- a/crates/gateway/docs/project_management/packs/active/chatgpt-codex-oauth-backend-api-responses/governance/seam-3-closeout.md
+++ b/crates/gateway/docs/project_management/packs/active/chatgpt-codex-oauth-backend-api-responses/governance/seam-3-closeout.md
@@ -1,11 +1,11 @@
 ---
 seam_id: SEAM-3
 status: landed
-closeout_version: v0
+closeout_version: v1
 seam_exit_gate:
   source_ref: docs/project_management/packs/active/chatgpt-codex-oauth-backend-api-responses/threaded-seams/seam-3-codex-route-conformance-and-drift-guards/slice-99-seam-exit-gate.md
-  status: pending
-  promotion_readiness: blocked
+  status: completed
+  promotion_readiness: ready
 basis:
   currentness: current
   upstream_closeouts:
@@ -15,11 +15,15 @@ basis:
     - THR-14
     - THR-15
     - THR-16
-  stale_triggers: []
+  stale_triggers:
+    - route compatibility classifications or supported Codex-route controls change from the published `pass | translate | force | reject` baseline
+    - semantic SSE event families, continuation assembly rules, or sync-drain terminal requirements change in a way that invalidates deterministic route parity expectations
+    - auth-handoff ownership, field identifiers, explicit-over-JWT precedence, or bounded fallback constraints change for the Codex route
+    - normalized-core behavior, Codex fixture namespaces, or evidence-anchor locations drift enough to obscure what the route regressions prove
 gates:
   post_exec:
-    landing: pending
-    closeout: pending
+    landing: passed
+    closeout: passed
 open_remediations: []
 ---
 
@@ -27,20 +31,34 @@ open_remediations: []
 
 ## Seam-exit gate record
 
-- **Source artifact**: reserved future seam-exit slice at `threaded-seams/seam-3-codex-route-conformance-and-drift-guards/slice-99-seam-exit-gate.md`
-- **Landed evidence**: pending deterministic fixture coverage, auth-source regressions, and route-maintenance documentation updates
-- **Contracts published or changed**: pending `C-16`
-- **Threads published / advanced**: pending `THR-16`
-- **Review-surface delta**: pending post-exec comparison against `R1`, `R2`, and `R3`
-- **Planned-vs-landed delta**: not yet executed
-- **Downstream stale triggers raised**: none recorded yet
-- **Remediation disposition**: no post-exec remediation has been opened yet
-- **Promotion blockers**: conformance contract publication, deterministic evidence, and closeout-backed seam-exit truth are all still missing
-- **Promotion readiness**: blocked
+- **Source artifact**: landed seam-exit slice at `threaded-seams/seam-3-codex-route-conformance-and-drift-guards/slice-99-seam-exit-gate.md`
+- **Landed evidence**:
+  - `S00` landed the canonical conformance baseline in `crates/gateway/docs/contracts/chatgpt-codex-conformance-and-drift-guard.md` via commit `eb610978`, freezing deterministic route, auth-provenance, fixture, and maintenance-doc obligations under `C-16`
+  - `S1` landed deterministic route-matrix and fixture coverage via commit `c9ae8e18`, including route-boundary regressions in `crates/gateway/tests/openai_responses_conformance.rs`, shared parity coverage in `crates/gateway/tests/openai_shared_parity.rs`, and the owned fixture family under `crates/gateway/tests/fixtures/openai_responses/codex-*.json`
+  - `S2` landed auth-provenance and failure-envelope evidence via commit `117b59ce`, strengthening route-boundary parity in `crates/gateway/tests/openai_shared_parity.rs` and aligning Codex auth maintenance guidance in `crates/gateway/docs/OAUTH_SETUP.md` and `crates/gateway/docs/OAUTH_TESTING.md`, with provider-side supporting proof in `crates/gateway/src/providers/openai.rs`
+  - `S3` landed route-specific maintenance guidance via commit `c3e34a57`, aligning `crates/gateway/docs/openai-compatibility.md`, `crates/gateway/docs/OAUTH_SETUP.md`, and `crates/gateway/docs/OAUTH_TESTING.md` to the same stale triggers and evidence anchors named by the conformance contract
+- **Contracts published or changed**:
+  - published `C-16` through `crates/gateway/docs/contracts/chatgpt-codex-conformance-and-drift-guard.md`
+- **Threads published / advanced**:
+  - published `THR-16` as the maintenance-facing drift-guard baseline for future Codex-route work
+- **Review-surface delta**:
+  - `R1` now has landed deterministic route-matrix, sync/stream parity, continuation, and no-silent-degradation evidence anchored in the Codex fixture-backed conformance suite
+  - `R2` now has landed auth-source, explicit-over-JWT precedence, pre-upstream failure, and shared auth-envelope evidence anchored in route-boundary parity tests plus aligned maintenance docs
+  - route-facing maintenance guidance now points back to the same contract and evidence surfaces rather than requiring ADR rediscovery during future revalidation
+- **Planned-vs-landed delta**:
+  - none material; the seam landed the planned canonical contract baseline, deterministic regression anchors, auth provenance proof, and maintenance-doc alignment without opening post-exec remediations
+- **Downstream stale triggers raised**:
+  - reopen `THR-16` when Codex-route control classifications, semantic event assembly, sync-drain terminal behavior, auth-source rules, normalized-core assumptions, fixture namespaces, or maintenance evidence anchors drift materially
+- **Remediation disposition**:
+  - no post-exec remediations were opened; the seam closed without carried-forward remediation work
+- **Promotion blockers**:
+  - none remaining inside this seam; the contract baseline, deterministic evidence set, and closeout-backed seam-exit truth are now all landed
+- **Promotion readiness**:
+  - ready; future Codex-route maintenance can consume `THR-16` as the authoritative drift-guard baseline without re-reading ADR discovery material
 
 ## Post-exec gate disposition
 
-- **Landing gate**: pending
-- **Closeout gate**: pending
+- **Landing gate**: passed
+- **Closeout gate**: passed
 - **Unresolved remediations**: none
 - **Carried-forward remediations**: none

--- a/crates/gateway/docs/project_management/packs/active/chatgpt-codex-oauth-backend-api-responses/governance/seam-3-closeout.md
+++ b/crates/gateway/docs/project_management/packs/active/chatgpt-codex-oauth-backend-api-responses/governance/seam-3-closeout.md
@@ -4,7 +4,7 @@ status: landed
 closeout_version: v1
 seam_exit_gate:
   source_ref: docs/project_management/packs/active/chatgpt-codex-oauth-backend-api-responses/threaded-seams/seam-3-codex-route-conformance-and-drift-guards/slice-99-seam-exit-gate.md
-  status: completed
+  status: passed
   promotion_readiness: ready
 basis:
   currentness: current

--- a/crates/gateway/docs/project_management/packs/active/chatgpt-codex-oauth-backend-api-responses/review_surfaces.md
+++ b/crates/gateway/docs/project_management/packs/active/chatgpt-codex-oauth-backend-api-responses/review_surfaces.md
@@ -1,0 +1,76 @@
+# Review Surfaces - ChatGPT Codex OAuth Backend-API Responses
+
+These diagrams orient the pack. They show the actual product/work shape that is expected to land.
+They do not, by themselves, satisfy seam-local pre-exec review.
+Active and next seams still require seam-local `review.md` artifacts later.
+
+## R1 - End-to-end routed Codex OAuth turn
+
+```mermaid
+flowchart LR
+  CALLER["Client via /v1/messages
+  /v1/chat/completions
+  or /v1/responses"] --> INGRESS["Public gateway ingress
+  stays thin"]
+  INGRESS --> CORE["Normalized GatewayRequest
+  + stream model"]
+  CORE --> ROUTE["Codex OAuth route selector
+  provider-side only"]
+  ROUTE --> UP["ChatGPT backend-api
+  /codex/responses
+  stream=true"]
+  UP --> SSE["Semantic SSE event flow"]
+  SSE --> SYNC["Sync drain assembly"]
+  SSE --> STREAM["Streaming transform"]
+  SYNC --> CALLER
+  STREAM --> CALLER
+```
+
+## R2 - Route compatibility and stream assembly boundary
+
+```mermaid
+flowchart TB
+  REQ["Normalized request controls"] --> MATRIX["Route-local matrix
+  pass | translate | force | reject"]
+  MATRIX --> SERIAL["Codex serializer
+  typed message items
+  flat tools
+  flat tool_choice"]
+  SERIAL --> HEADERS["Minimal header contract
+  Authorization
+  ChatGPT-Account-ID
+  Content-Type"]
+  HEADERS --> UP["backend-api/codex/responses"]
+  UP --> EVENTS["response.created
+  response.output_item.*
+  response.output_text.*
+  response.function_call_arguments.*
+  response.completed"]
+  EVENTS --> ASSEMBLY["Semantic output + tool assembly"]
+  ASSEMBLY --> OUT["GatewayResponse
+  or normalized stream"]
+```
+
+## R3 - Integrated auth-handoff owner line
+
+```mermaid
+flowchart LR
+  HOST["Host-side Substrate
+  credential preflight"] --> BUNDLE["Secret-channel auth bundle
+  cli:codex fields"]
+  BUNDLE --> WORLD["In-world gateway runtime"]
+  WORLD --> AUTHCTX["Resolved auth context
+  explicit account_id first"]
+  AUTHCTX --> PROVIDER["Provider request builder"]
+  PROVIDER --> HEADER["ChatGPT-Account-ID
+  injection"]
+  HEADER --> UP["backend-api/codex/responses"]
+  LOCAL["Standalone local auth state
+  bounded fallback only"] --> AUTHCTX
+```
+
+## Review intent
+
+- `R1` makes the delivery target explicit: public ingress stays thin while the routed provider path becomes a dedicated ChatGPT Codex transport
+- `R2` highlights the seam-1 review surface that must become canonical before implementation: compatibility classification, serializer shape, minimal headers, and semantic event assembly
+- `R3` makes the seam-2 trust boundary explicit so integrated auth delivery and standalone fallback cannot blur into one implicit owner line

--- a/crates/gateway/docs/project_management/packs/active/chatgpt-codex-oauth-backend-api-responses/scope_brief.md
+++ b/crates/gateway/docs/project_management/packs/active/chatgpt-codex-oauth-backend-api-responses/scope_brief.md
@@ -1,0 +1,57 @@
+---
+pack_id: chatgpt-codex-oauth-backend-api-responses
+pack_version: v1
+pack_status: extracted
+source_ref: docs/adr/0010-route-chatgpt-codex-oauth-via-backend-api-codex-responses.md plus current gateway OAuth/provider/auth surfaces in crates/gateway/src/
+execution_horizon:
+  active_seam: SEAM-1
+  next_seam: SEAM-2
+---
+
+# Scope Brief - ChatGPT Codex OAuth Backend-API Responses
+
+- **Goal**: route ChatGPT Codex OAuth traffic through a dedicated `backend-api/codex/responses` transport contract that preserves the gateway's normalized-core architecture, assembles results from semantic stream events, and keeps Substrate as the authoritative owner of integrated auth-state delivery.
+- **Why now**: the current gateway is close enough to route ChatGPT Codex OAuth traffic, but still has material drift from the live upstream contract: sync and streaming hit different endpoints, the serializer still emits unsupported generic Responses fields/shapes, the sync parser trusts the wrong terminal envelope, and account identity still depends on JWT parsing instead of an explicit owner line.
+- **Primary user(s) + JTBD**:
+  - Gateway callers using `/v1/messages`, `/v1/chat/completions`, or `/v1/responses` want the selected ChatGPT Codex OAuth route to behave predictably for streaming, tool continuation, and image-bearing message turns without exposing route-specific quirks at public ingress.
+  - Gateway and Substrate operators want an integrated deployment posture where account identity and access-token delivery stay policy-gated and in-world-compatible, rather than depending on host-local auth file reads inside the gateway runtime.
+  - Gateway maintainers want deterministic drift guards for an undocumented upstream backend so future changes fail loudly instead of silently degrading caller-visible controls.
+- **In-scope**:
+  - freeze a dedicated ChatGPT Codex route contract for `https://chatgpt.com/backend-api/codex/responses`
+  - freeze the route-local compatibility overlay for `pass | translate | force | reject` behavior across supported request controls
+  - make the provider path stream-native for both sync and streaming callers, including semantic event assembly and sync-drain failure rules
+  - freeze a Substrate-owned auth-handoff contract for integrated mode and a bounded standalone compatibility path
+  - lock the route into deterministic conformance, regression, and documentation surfaces
+- **Out-of-scope**:
+  - redesigning public ingress or creating a second execution engine outside the normalized core
+  - widening the public OpenAI-side contract beyond what ADR 0010 verifies for this route
+  - exposing encrypted reasoning content as public OpenAI-visible output
+  - making gateway-local token storage or local auth files into required trust inputs for Substrate-managed in-world operation
+  - adding ChatGPT Codex built-in tools, non-function tools, or unverified structured-output features
+- **Success criteria**:
+  - sync and streaming both use `/backend-api/codex/responses` with `stream = true` and `store = false`
+  - the Codex route serializer only emits the verified-supported field subset and route-local compatibility matrix, with flat tool/tool-choice shapes and typed `message` items
+  - answer assembly and tool-argument assembly come from semantic stream events rather than `response.completed.response.output`
+  - integrated mode resolves `ChatGPT-Account-ID` from Substrate-delivered auth context first, with JWT extraction kept as bounded fallback only
+  - deterministic conformance proves request-shape gating, reasoning gating, continuation synthesis/order rules, sync-drain failure behavior, and auth-source boundaries
+- **Constraints**:
+  - ADR 0010 is the normative route decision
+  - `docs/IMPORTANT_SUBSTRATE_ALIGNMENT.md` still forbids a second backend identity, host-local architectural assumptions, and raw-provider-stream coupling
+  - the landed OpenAI-side public contracts under `docs/foundation/openai-side-*.md` remain upstream basis for public ingress behavior; this pack changes provider-side route handling only
+  - the ChatGPT Codex upstream is undocumented and drift-prone, so new compatibility only lands when explicitly verified
+  - canonical contract docs are reserved under `docs/contracts/` for this pack even though that tree does not yet exist in the repo
+- **External systems / dependencies**:
+  - `https://chatgpt.com/backend-api/codex/responses`
+  - ChatGPT Codex OAuth auth material and account identity
+  - Substrate host preflight, secret delivery, and in-world gateway deployment posture
+  - current gateway provider/auth/server modules under `crates/gateway/src/`
+  - current OpenAI-side conformance harness under `crates/gateway/tests/`
+- **Known unknowns / risks**:
+  - the exact integrated auth-handoff artifact and delivery surface are not yet frozen inside this repo
+  - the current token store schema has no explicit `account_id`, so seam-local planning must decide how standalone compatibility resolves that gap without redefining integrated ownership
+  - live upstream event ordering or accepted-field behavior may drift after the 2026-04-11 probe evidence captured in the ADR
+  - sync-drain adaptation is easy to get almost-right while still returning partial or misassembled output on malformed streams
+- **Assumptions**:
+  - the ADR's gap list is correct: both the route contract and the auth-handoff contract must be authored before downstream implementation slices can promote
+  - existing public ingress handlers remain thin adapters over the same normalized `GatewayRequest` and stream model
+  - the right seam split is provider route contract first, then auth ownership, then conformance and docs

--- a/crates/gateway/docs/project_management/packs/active/chatgpt-codex-oauth-backend-api-responses/scope_brief.md
+++ b/crates/gateway/docs/project_management/packs/active/chatgpt-codex-oauth-backend-api-responses/scope_brief.md
@@ -4,7 +4,7 @@ pack_version: v1
 pack_status: extracted
 source_ref: docs/adr/0010-route-chatgpt-codex-oauth-via-backend-api-codex-responses.md plus current gateway OAuth/provider/auth surfaces in crates/gateway/src/
 execution_horizon:
-  active_seam: SEAM-3
+  active_seam: null
   next_seam: null
 ---
 

--- a/crates/gateway/docs/project_management/packs/active/chatgpt-codex-oauth-backend-api-responses/scope_brief.md
+++ b/crates/gateway/docs/project_management/packs/active/chatgpt-codex-oauth-backend-api-responses/scope_brief.md
@@ -4,14 +4,14 @@ pack_version: v1
 pack_status: extracted
 source_ref: docs/adr/0010-route-chatgpt-codex-oauth-via-backend-api-codex-responses.md plus current gateway OAuth/provider/auth surfaces in crates/gateway/src/
 execution_horizon:
-  active_seam: SEAM-2
+  active_seam: SEAM-3
   next_seam: null
 ---
 
 # Scope Brief - ChatGPT Codex OAuth Backend-API Responses
 
 - **Goal**: route ChatGPT Codex OAuth traffic through a dedicated `backend-api/codex/responses` transport contract that preserves the gateway's normalized-core architecture, assembles results from semantic stream events, and keeps Substrate as the authoritative owner of integrated auth-state delivery.
-- **Why now**: the current gateway is close enough to route ChatGPT Codex OAuth traffic, but still has material drift from the live upstream contract: sync and streaming hit different endpoints, the serializer still emits unsupported generic Responses fields/shapes, the sync parser trusts the wrong terminal envelope, and account identity still depends on JWT parsing instead of an explicit owner line.
+- **Why now**: the route and auth ownership seams are now landed, so the remaining gap is to turn that published truth into deterministic conformance and drift guards before future edits can silently reopen route or auth regressions.
 - **Primary user(s) + JTBD**:
   - Gateway callers using `/v1/messages`, `/v1/chat/completions`, or `/v1/responses` want the selected ChatGPT Codex OAuth route to behave predictably for streaming, tool continuation, and image-bearing message turns without exposing route-specific quirks at public ingress.
   - Gateway and Substrate operators want an integrated deployment posture where account identity and access-token delivery stay policy-gated and in-world-compatible, rather than depending on host-local auth file reads inside the gateway runtime.

--- a/crates/gateway/docs/project_management/packs/active/chatgpt-codex-oauth-backend-api-responses/scope_brief.md
+++ b/crates/gateway/docs/project_management/packs/active/chatgpt-codex-oauth-backend-api-responses/scope_brief.md
@@ -4,8 +4,8 @@ pack_version: v1
 pack_status: extracted
 source_ref: docs/adr/0010-route-chatgpt-codex-oauth-via-backend-api-codex-responses.md plus current gateway OAuth/provider/auth surfaces in crates/gateway/src/
 execution_horizon:
-  active_seam: SEAM-1
-  next_seam: SEAM-2
+  active_seam: SEAM-2
+  next_seam: null
 ---
 
 # Scope Brief - ChatGPT Codex OAuth Backend-API Responses

--- a/crates/gateway/docs/project_management/packs/active/chatgpt-codex-oauth-backend-api-responses/scope_brief.md
+++ b/crates/gateway/docs/project_management/packs/active/chatgpt-codex-oauth-backend-api-responses/scope_brief.md
@@ -39,7 +39,7 @@ execution_horizon:
   - `docs/IMPORTANT_SUBSTRATE_ALIGNMENT.md` still forbids a second backend identity, host-local architectural assumptions, and raw-provider-stream coupling
   - the landed OpenAI-side public contracts under `docs/foundation/openai-side-*.md` remain upstream basis for public ingress behavior; this pack changes provider-side route handling only
   - the ChatGPT Codex upstream is undocumented and drift-prone, so new compatibility only lands when explicitly verified
-  - canonical contract docs are reserved under `docs/contracts/` for this pack even though that tree does not yet exist in the repo
+  - canonical contract docs are reserved under `crates/gateway/docs/contracts/` for this pack and must remain descriptive-only
 - **External systems / dependencies**:
   - `https://chatgpt.com/backend-api/codex/responses`
   - ChatGPT Codex OAuth auth material and account identity

--- a/crates/gateway/docs/project_management/packs/active/chatgpt-codex-oauth-backend-api-responses/seam-1-chatgpt-codex-route-contract-and-stream-native-transport.md
+++ b/crates/gateway/docs/project_management/packs/active/chatgpt-codex-oauth-backend-api-responses/seam-1-chatgpt-codex-route-contract-and-stream-native-transport.md
@@ -1,0 +1,112 @@
+---
+seam_id: SEAM-1
+seam_slug: chatgpt-codex-route-contract-and-stream-native-transport
+type: integration
+status: proposed
+execution_horizon: active
+plan_version: v1
+basis:
+  currentness: provisional
+  source_scope_ref: scope_brief.md
+  source_scope_version: v1
+  upstream_closeouts:
+    - docs/project_management/packs/active/openai-side-chat-completions-and-responses/governance/seam-2-closeout.md
+    - docs/project_management/packs/active/openai-side-chat-completions-and-responses/governance/seam-3-closeout.md
+  required_threads: []
+  stale_triggers:
+    - the live ChatGPT Codex backend changes accepted fields, required headers, or semantic event ordering relative to the 2026-04-11 probe evidence captured in ADR 0010
+    - the normalized `GatewayRequest` or stream model changes in a way that invalidates the route-local compatibility matrix or continuation provenance assumptions
+    - public OpenAI-side contracts widen or tighten supported controls in a way that forces this route to reinterpret `pass`, `translate`, `force`, or `reject`
+gates:
+  pre_exec:
+    review: pending
+    contract: pending
+    revalidation: pending
+  post_exec:
+    landing: pending
+    closeout: pending
+seam_exit_gate:
+  required: true
+  planned_location: S99
+  status: pending
+open_remediations: []
+---
+
+# SEAM-1 - ChatGPT Codex Route Contract And Stream-Native Transport
+
+- **Goal / value**: freeze the ChatGPT Codex OAuth provider route as one explicit upstream transport contract so the gateway can preserve caller-visible semantics while speaking the verified `backend-api/codex/responses` subset.
+- **Scope**
+  - In:
+    - one endpoint for both sync and streaming: `https://chatgpt.com/backend-api/codex/responses`
+    - the route-local `pass | translate | force | reject` compatibility matrix
+    - typed `message` item emission, flat function tool serialization, flat explicit `tool_choice`, and ordered `function_call` + `function_call_output` continuation handling
+    - semantic stream assembly from `response.output_item.*`, `response.content_part.*`, `response.output_text.*`, and `response.function_call_arguments.*`
+    - sync-drain failure rules, including `502 transport_drift` on malformed or truncated drains
+    - route-local reasoning gating and the rule that encrypted reasoning stays internal on this route
+  - Out:
+    - redesigning public `/v1/messages`, `/v1/chat/completions`, or `/v1/responses`
+    - widening route support to unverified generic Responses fields or built-in tools
+    - changing auth ownership beyond what is required to define the route contract inputs this seam consumes
+- **Primary interfaces**
+  - Inputs:
+    - normalized `GatewayRequest` values routed to the ChatGPT Codex OAuth provider path
+    - ADR 0010 route evidence and the landed OpenAI-side public contract basis
+    - current provider implementation in `crates/gateway/src/providers/openai.rs`
+  - Outputs:
+    - `C-14` ChatGPT Codex route contract
+    - explicit route-local compatibility rules for supported and rejected controls
+    - provider request/response behavior that uses one stream-native upstream event source for sync and streaming
+- **Key invariants / rules**:
+  - sync and streaming use the same upstream endpoint and the same minimal header contract
+  - `stream = true` and `store = false` are route-forced invariants
+  - typed `message` items are the canonical outbound form on this route
+  - continuation repair is minimal and provenance-based: synthesized `function_call` items are only allowed when authoritative normalized provenance already exists
+  - `response.completed` is lifecycle and usage truth, not the assembled-answer source of truth
+  - encrypted reasoning content never becomes public OpenAI-visible text on this route
+- **Dependencies**
+  - Direct blockers:
+    - none inside this pack; the seam is first because the ADR already identified the route contract as the prerequisite gap
+  - Transitive blockers:
+    - later conformance work depends on the route contract freezing exact accepted and rejected controls
+  - Direct consumers:
+    - `SEAM-2`
+    - `SEAM-3`
+  - Derived consumers:
+    - future Codex-route maintenance and any later provider-side feature work that must preserve this route's public semantics
+- **Touch surface**:
+  - `crates/gateway/src/providers/openai.rs`
+  - `crates/gateway/src/providers/streaming.rs`
+  - `crates/gateway/src/server/openai_responses.rs`
+  - `crates/gateway/src/models/mod.rs`
+  - `crates/gateway/tests/openai_responses_conformance.rs`
+  - `crates/gateway/tests/openai_shared_parity.rs`
+  - route-specific contract docs reserved under `docs/contracts/`
+- **Verification**:
+  - If this seam **consumes** an upstream contract, verification may depend on accepted upstream evidence.
+  - If this seam **produces** an owned contract, verification should describe the contract becoming concrete enough for seam-local planning and implementation rather than requiring the final accepted artifact to exist already.
+  - Verify the route contract is concrete enough that seam-local planning can name exact request fields, header rules, semantic event families, continuation legality, and sync-drain failure behavior.
+  - Verify deterministic provider-focused tests can prove endpoint parity, field allowlist/reject posture, reasoning gating, continuation ordering, and semantic assembly from the stream event family.
+  - Verify unsupported caller-visible controls fail explicitly rather than being silently stripped or degraded on this route.
+- **Canonical contract refs**:
+  - `docs/contracts/chatgpt-codex-route-contract.md`
+- **Risks / unknowns**:
+  - Risk: the undocumented upstream backend drifts after the probes captured in ADR 0010.
+  - De-risk plan: freeze the route contract and bind it to deterministic request/stream fixtures instead of leaving behavior implicit in provider code.
+  - Risk: route work bleeds upward into public ingress or sideways into auth ownership.
+  - De-risk plan: keep public ingress as consumed basis and leave auth provenance to `SEAM-2`.
+  - Risk: semantic event assembly returns apparently valid but partial sync output on truncated streams.
+  - De-risk plan: make `response.completed` mandatory and force `502 transport_drift` on malformed sync drains.
+- **Rollout / safety**:
+  - keep the route-specific logic below public ingress and inside the selected provider path
+  - preserve explicit request rejection for unsupported controls
+  - keep reasoning payloads internal and non-public on this route
+- **Downstream decomposition context**:
+  - Why this seam is `active`, `next`, or `future`: it is `active` because both auth ownership and conformance need the route contract to exist as published basis first
+  - Which threads matter most: `THR-14`
+  - What the first seam-local review should focus on: route-local control classification, serializer legality, semantic event assembly, sync-drain failure posture, and keeping public ingress thin
+- **Expected seam-exit concerns**:
+  - Contracts likely to publish: `C-14`
+  - Threads likely to advance: `THR-14`
+  - Review-surface areas likely to shift after landing: `R1` and `R2` will gain concrete named route/fixture anchors; `R3` may tighten around the exact auth-context input that `SEAM-1` consumes
+  - Downstream seams most likely to require revalidation: `SEAM-2`, `SEAM-3`
+  - Accepted or published owned-contract artifacts belong here and in closeout evidence, not in pre-exec verification for the producing seam.

--- a/crates/gateway/docs/project_management/packs/active/chatgpt-codex-oauth-backend-api-responses/seam-1-chatgpt-codex-route-contract-and-stream-native-transport.md
+++ b/crates/gateway/docs/project_management/packs/active/chatgpt-codex-oauth-backend-api-responses/seam-1-chatgpt-codex-route-contract-and-stream-native-transport.md
@@ -3,7 +3,7 @@ seam_id: SEAM-1
 seam_slug: chatgpt-codex-route-contract-and-stream-native-transport
 type: integration
 status: landed
-execution_horizon: active
+execution_horizon: future
 plan_version: v2
 basis:
   currentness: current
@@ -101,7 +101,7 @@ open_remediations: []
   - preserve explicit request rejection for unsupported controls
   - keep reasoning payloads internal and non-public on this route
 - **Downstream decomposition context**:
-  - Why this seam is `active`, `next`, or `future`: it is `landed` because both auth ownership and conformance now consume the published route contract as basis
+  - Why this seam is `active`, `next`, or `future`: it is `future` because both auth ownership and conformance now consume the published route contract as basis and the seam is out of the forward window
   - Which threads matter most: `THR-14`
   - What the first seam-local review should focus on: route-local control classification, serializer legality, semantic event assembly, sync-drain failure posture, and keeping public ingress thin
 - **Expected seam-exit concerns**:

--- a/crates/gateway/docs/project_management/packs/active/chatgpt-codex-oauth-backend-api-responses/seam-1-chatgpt-codex-route-contract-and-stream-native-transport.md
+++ b/crates/gateway/docs/project_management/packs/active/chatgpt-codex-oauth-backend-api-responses/seam-1-chatgpt-codex-route-contract-and-stream-native-transport.md
@@ -2,7 +2,7 @@
 seam_id: SEAM-1
 seam_slug: chatgpt-codex-route-contract-and-stream-native-transport
 type: integration
-status: exec-ready
+status: landed
 execution_horizon: active
 plan_version: v2
 basis:
@@ -23,12 +23,12 @@ gates:
     contract: passed
     revalidation: passed
   post_exec:
-    landing: pending
-    closeout: pending
+    landing: passed
+    closeout: passed
 seam_exit_gate:
   required: true
   planned_location: S99
-  status: pending
+  status: passed
 open_remediations: []
 ---
 
@@ -101,7 +101,7 @@ open_remediations: []
   - preserve explicit request rejection for unsupported controls
   - keep reasoning payloads internal and non-public on this route
 - **Downstream decomposition context**:
-  - Why this seam is `active`, `next`, or `future`: it is `active` because both auth ownership and conformance need the route contract to exist as published basis first
+  - Why this seam is `active`, `next`, or `future`: it is `landed` because both auth ownership and conformance now consume the published route contract as basis
   - Which threads matter most: `THR-14`
   - What the first seam-local review should focus on: route-local control classification, serializer legality, semantic event assembly, sync-drain failure posture, and keeping public ingress thin
 - **Expected seam-exit concerns**:

--- a/crates/gateway/docs/project_management/packs/active/chatgpt-codex-oauth-backend-api-responses/seam-1-chatgpt-codex-route-contract-and-stream-native-transport.md
+++ b/crates/gateway/docs/project_management/packs/active/chatgpt-codex-oauth-backend-api-responses/seam-1-chatgpt-codex-route-contract-and-stream-native-transport.md
@@ -2,16 +2,16 @@
 seam_id: SEAM-1
 seam_slug: chatgpt-codex-route-contract-and-stream-native-transport
 type: integration
-status: proposed
+status: exec-ready
 execution_horizon: active
-plan_version: v1
+plan_version: v2
 basis:
-  currentness: provisional
+  currentness: current
   source_scope_ref: scope_brief.md
   source_scope_version: v1
   upstream_closeouts:
-    - docs/project_management/packs/active/openai-side-chat-completions-and-responses/governance/seam-2-closeout.md
-    - docs/project_management/packs/active/openai-side-chat-completions-and-responses/governance/seam-3-closeout.md
+    - crates/gateway/docs/project_management/packs/active/openai-side-chat-completions-and-responses/governance/seam-2-closeout.md
+    - crates/gateway/docs/project_management/packs/active/openai-side-chat-completions-and-responses/governance/seam-3-closeout.md
   required_threads: []
   stale_triggers:
     - the live ChatGPT Codex backend changes accepted fields, required headers, or semantic event ordering relative to the 2026-04-11 probe evidence captured in ADR 0010
@@ -19,9 +19,9 @@ basis:
     - public OpenAI-side contracts widen or tighten supported controls in a way that forces this route to reinterpret `pass`, `translate`, `force`, or `reject`
 gates:
   pre_exec:
-    review: pending
-    contract: pending
-    revalidation: pending
+    review: passed
+    contract: passed
+    revalidation: passed
   post_exec:
     landing: pending
     closeout: pending
@@ -80,7 +80,7 @@ open_remediations: []
   - `crates/gateway/src/models/mod.rs`
   - `crates/gateway/tests/openai_responses_conformance.rs`
   - `crates/gateway/tests/openai_shared_parity.rs`
-  - route-specific contract docs reserved under `docs/contracts/`
+  - route-specific contract docs reserved under `crates/gateway/docs/contracts/`
 - **Verification**:
   - If this seam **consumes** an upstream contract, verification may depend on accepted upstream evidence.
   - If this seam **produces** an owned contract, verification should describe the contract becoming concrete enough for seam-local planning and implementation rather than requiring the final accepted artifact to exist already.
@@ -88,7 +88,7 @@ open_remediations: []
   - Verify deterministic provider-focused tests can prove endpoint parity, field allowlist/reject posture, reasoning gating, continuation ordering, and semantic assembly from the stream event family.
   - Verify unsupported caller-visible controls fail explicitly rather than being silently stripped or degraded on this route.
 - **Canonical contract refs**:
-  - `docs/contracts/chatgpt-codex-route-contract.md`
+  - `crates/gateway/docs/contracts/chatgpt-codex-route-contract.md`
 - **Risks / unknowns**:
   - Risk: the undocumented upstream backend drifts after the probes captured in ADR 0010.
   - De-risk plan: freeze the route contract and bind it to deterministic request/stream fixtures instead of leaving behavior implicit in provider code.

--- a/crates/gateway/docs/project_management/packs/active/chatgpt-codex-oauth-backend-api-responses/seam-2-substrate-auth-handoff-and-account-id-provenance.md
+++ b/crates/gateway/docs/project_management/packs/active/chatgpt-codex-oauth-backend-api-responses/seam-2-substrate-auth-handoff-and-account-id-provenance.md
@@ -1,0 +1,109 @@
+---
+seam_id: SEAM-2
+seam_slug: substrate-auth-handoff-and-account-id-provenance
+type: integration
+status: proposed
+execution_horizon: next
+plan_version: v1
+basis:
+  currentness: provisional
+  source_scope_ref: scope_brief.md
+  source_scope_version: v1
+  upstream_closeouts: []
+  required_threads:
+    - THR-14
+  stale_triggers:
+    - the route contract changes the required header contract or the exact auth-context fields the provider path consumes
+    - Substrate delivery posture changes for auth bundles, secret-channel transport, or in-world consumption
+    - standalone compatibility sources differ from the current ADR assumptions about `~/.codex/auth.json` and JWT fallback
+gates:
+  pre_exec:
+    review: pending
+    contract: pending
+    revalidation: pending
+  post_exec:
+    landing: pending
+    closeout: pending
+seam_exit_gate:
+  required: true
+  planned_location: S99
+  status: pending
+open_remediations: []
+---
+
+# SEAM-2 - Substrate Auth Handoff And Account-Id Provenance
+
+- **Goal / value**: freeze the integrated-versus-standalone auth owner line so `ChatGPT-Account-ID` and access-token delivery are explicit, policy-compatible, and reviewable instead of being inferred from provider-local token parsing.
+- **Scope**
+  - In:
+    - Substrate-owned integrated-mode auth delivery and account-id ownership
+    - standalone compatibility posture and its bounded fallback order
+    - the closed `cli:codex` auth field set and gateway-consumed field identifiers
+    - gateway auth-context resolution and pre-upstream failure behavior when no valid account identity exists
+    - provider request-builder injection of `ChatGPT-Account-ID` from resolved auth context
+  - Out:
+    - redesigning the OAuth browser flow or token-refresh UX
+    - turning standalone local auth files into integrated-mode architecture
+    - broad Substrate deployment planning beyond the gateway-side auth-handoff boundary this route needs
+- **Primary interfaces**
+  - Inputs:
+    - `C-14` route contract and its minimal header contract
+    - current gateway auth surfaces in `crates/gateway/src/auth/*` and `crates/gateway/src/server/oauth_handlers.rs`
+    - current provider-side account-id extraction behavior in `crates/gateway/src/providers/openai.rs`
+    - Substrate boundary constraints from `docs/IMPORTANT_SUBSTRATE_ALIGNMENT.md`, ADR 0005, and ADR 0006
+  - Outputs:
+    - `C-15` ChatGPT Codex auth-handoff contract
+    - explicit integrated-mode and standalone-mode account-id resolution order
+    - verification surfaces for host preflight, delivery, gateway consumption, and provider injection
+- **Key invariants / rules**:
+  - integrated mode consumes Substrate-delivered auth context and must not require direct reads of `~/.codex/auth.json` or other host-local auth files inside the in-world gateway runtime
+  - explicit `account_id` wins over JWT-derived fallback whenever both exist
+  - JWT extraction is compatibility fallback only and must not redefine auth ownership
+  - the gateway consumes resolved auth context; it does not become the authority for host credential reads or trust-boundary decisions
+  - if no valid account identity can be resolved for the selected mode, the gateway fails before the upstream call using the normal error envelope
+- **Dependencies**
+  - Direct blockers:
+    - `THR-14` must publish the route contract so this seam knows the exact auth inputs and minimal header set it is serving
+  - Transitive blockers:
+    - any later conformance work depends on this seam freezing integrated-versus-standalone ownership and failure posture
+  - Direct consumers:
+    - `SEAM-3`
+  - Derived consumers:
+    - future Substrate-managed deployment and maintenance work outside this pack
+- **Touch surface**:
+  - `crates/gateway/src/auth/oauth.rs`
+  - `crates/gateway/src/auth/token_store.rs`
+  - `crates/gateway/src/server/oauth_handlers.rs`
+  - `crates/gateway/src/providers/openai.rs`
+  - `crates/gateway/docs/OAUTH_SETUP.md`
+  - `crates/gateway/docs/OAUTH_TESTING.md`
+  - auth-handoff contract docs reserved under `docs/contracts/`
+- **Verification**:
+  - If this seam **consumes** an upstream contract, verification may depend on accepted upstream evidence.
+  - If this seam **produces** an owned contract, verification should describe the contract becoming concrete enough for seam-local planning and implementation rather than requiring the final accepted artifact to exist already.
+  - Verify the auth-handoff contract is concrete enough to name the integrated-mode owner line, the standalone fallback path, the required field identifiers, and the exact pre-upstream failure posture.
+  - Verify the gateway-side resolution path can distinguish integrated and standalone mode without letting gateway-local persistence become a required integrated trust input.
+  - Verify the provider path can inject `ChatGPT-Account-ID` from resolved auth context first and use JWT parsing only as bounded fallback.
+- **Canonical contract refs**:
+  - `docs/contracts/chatgpt-codex-auth-handoff-contract.md`
+- **Risks / unknowns**:
+  - Risk: the current token store schema lacks explicit `account_id`, making it easy for standalone compatibility to leak into integrated architecture.
+  - De-risk plan: freeze the owner line and field set before seam-local implementation work starts.
+  - Risk: auth-handoff work spreads into generic OAuth UX or unrelated provider cleanup.
+  - De-risk plan: keep the seam scoped to account-id provenance, delivery, injection, and failure posture for the Codex route.
+  - Risk: env vars become secret-bearing architecture instead of pointer semantics.
+  - De-risk plan: keep any env-var usage limited to bundle-pointer semantics and document the real secret channel explicitly.
+- **Rollout / safety**:
+  - preserve standalone compatibility while making integrated mode authoritative
+  - fail before the upstream call when account identity is unresolved or inconsistent
+  - keep secret-bearing data out of public docs and non-secret pointer semantics only in process env
+- **Downstream decomposition context**:
+  - Why this seam is `active`, `next`, or `future`: it is `next` because auth ownership is the next critical blocker after the route contract and must publish before deterministic conformance can close the pack
+  - Which threads matter most: `THR-14`, `THR-15`
+  - What the first seam-local review should focus on: integrated-versus-standalone mode selection, field IDs, resolution precedence, provider injection ownership, and failure classification
+- **Expected seam-exit concerns**:
+  - Contracts likely to publish: `C-15`
+  - Threads likely to advance: `THR-15`
+  - Review-surface areas likely to shift after landing: `R3` will tighten around concrete bundle shape and provider-consumption points; `R1` may annotate integrated-versus-standalone selection
+  - Downstream seams most likely to require revalidation: `SEAM-3`
+  - Accepted or published owned-contract artifacts belong here and in closeout evidence, not in pre-exec verification for the producing seam.

--- a/crates/gateway/docs/project_management/packs/active/chatgpt-codex-oauth-backend-api-responses/seam-2-substrate-auth-handoff-and-account-id-provenance.md
+++ b/crates/gateway/docs/project_management/packs/active/chatgpt-codex-oauth-backend-api-responses/seam-2-substrate-auth-handoff-and-account-id-provenance.md
@@ -2,7 +2,7 @@
 seam_id: SEAM-2
 seam_slug: substrate-auth-handoff-and-account-id-provenance
 type: integration
-status: decomposed
+status: exec-ready
 execution_horizon: active
 plan_version: v2
 basis:
@@ -20,7 +20,7 @@ basis:
 gates:
   pre_exec:
     review: passed
-    contract: failed
+    contract: passed
     revalidation: passed
   post_exec:
     landing: pending
@@ -65,7 +65,7 @@ open_remediations:
   - if no valid account identity can be resolved for the selected mode, the gateway fails before the upstream call using the normal error envelope
 - **Dependencies**
   - Direct blockers:
-    - the owned auth-handoff contract baseline is not yet written into the canonical contract path
+    - none at pre-exec; the owned auth-handoff contract baseline and execution checklist now exist, and the remaining open work is the landing-phase checklist tracked by `REM-001`
   - Transitive blockers:
     - any later conformance work depends on this seam freezing integrated-versus-standalone ownership and failure posture
   - Direct consumers:
@@ -87,7 +87,7 @@ open_remediations:
   - Verify the gateway-side resolution path can distinguish integrated and standalone mode without letting gateway-local persistence become a required integrated trust input.
   - Verify the provider path can inject `ChatGPT-Account-ID` from resolved auth context first and use JWT parsing only as bounded fallback.
 - **Canonical contract refs**:
-  - `docs/contracts/chatgpt-codex-auth-handoff-contract.md`
+  - `crates/gateway/docs/contracts/chatgpt-codex-auth-handoff-contract.md`
 - **Risks / unknowns**:
   - Risk: the current token store schema lacks explicit `account_id`, making it easy for standalone compatibility to leak into integrated architecture.
   - De-risk plan: freeze the owner line and field set before seam-local implementation work starts.
@@ -100,7 +100,7 @@ open_remediations:
   - fail before the upstream call when account identity is unresolved or inconsistent
   - keep secret-bearing data out of public docs and non-secret pointer semantics only in process env
 - **Downstream decomposition context**:
-  - Why this seam is `active`, `next`, or `future`: it is `active` because the route contract is now landed and the remaining blocker is the auth-handoff contract baseline
+  - Why this seam is `active`, `next`, or `future`: it is `active` because the route contract is landed and the auth-handoff contract baseline is now concrete enough for execution-grade slices
   - Which threads matter most: `THR-14`, `THR-15`
   - What the first seam-local review should focus on: integrated-versus-standalone mode selection, field IDs, resolution precedence, provider injection ownership, and failure classification
 - **Expected seam-exit concerns**:

--- a/crates/gateway/docs/project_management/packs/active/chatgpt-codex-oauth-backend-api-responses/seam-2-substrate-auth-handoff-and-account-id-provenance.md
+++ b/crates/gateway/docs/project_management/packs/active/chatgpt-codex-oauth-backend-api-responses/seam-2-substrate-auth-handoff-and-account-id-provenance.md
@@ -2,8 +2,8 @@
 seam_id: SEAM-2
 seam_slug: substrate-auth-handoff-and-account-id-provenance
 type: integration
-status: exec-ready
-execution_horizon: active
+status: landed
+execution_horizon: future
 plan_version: v2
 basis:
   currentness: current
@@ -23,14 +23,13 @@ gates:
     contract: passed
     revalidation: passed
   post_exec:
-    landing: pending
-    closeout: pending
+    landing: passed
+    closeout: passed
 seam_exit_gate:
   required: true
   planned_location: S99
-  status: pending
-open_remediations:
-  - REM-001
+  status: passed
+open_remediations: []
 ---
 
 # SEAM-2 - Substrate Auth Handoff And Account-Id Provenance
@@ -65,7 +64,7 @@ open_remediations:
   - if no valid account identity can be resolved for the selected mode, the gateway fails before the upstream call using the normal error envelope
 - **Dependencies**
   - Direct blockers:
-    - none at pre-exec; the owned auth-handoff contract baseline and execution checklist now exist, and the remaining open work is the landing-phase checklist tracked by `REM-001`
+    - none; the auth-handoff owner line, provider consumption path, and verification evidence are landed and published
   - Transitive blockers:
     - any later conformance work depends on this seam freezing integrated-versus-standalone ownership and failure posture
   - Direct consumers:
@@ -100,7 +99,7 @@ open_remediations:
   - fail before the upstream call when account identity is unresolved or inconsistent
   - keep secret-bearing data out of public docs and non-secret pointer semantics only in process env
 - **Downstream decomposition context**:
-  - Why this seam is `active`, `next`, or `future`: it is `active` because the route contract is landed and the auth-handoff contract baseline is now concrete enough for execution-grade slices
+  - Why this seam is `active`, `next`, or `future`: it is `future` because the auth-handoff seam is landed and now lives outside the forward planning window
   - Which threads matter most: `THR-14`, `THR-15`
   - What the first seam-local review should focus on: integrated-versus-standalone mode selection, field IDs, resolution precedence, provider injection ownership, and failure classification
 - **Expected seam-exit concerns**:

--- a/crates/gateway/docs/project_management/packs/active/chatgpt-codex-oauth-backend-api-responses/seam-2-substrate-auth-handoff-and-account-id-provenance.md
+++ b/crates/gateway/docs/project_management/packs/active/chatgpt-codex-oauth-backend-api-responses/seam-2-substrate-auth-handoff-and-account-id-provenance.md
@@ -2,14 +2,15 @@
 seam_id: SEAM-2
 seam_slug: substrate-auth-handoff-and-account-id-provenance
 type: integration
-status: proposed
-execution_horizon: next
-plan_version: v1
+status: decomposed
+execution_horizon: active
+plan_version: v2
 basis:
-  currentness: provisional
+  currentness: current
   source_scope_ref: scope_brief.md
   source_scope_version: v1
-  upstream_closeouts: []
+  upstream_closeouts:
+    - governance/seam-1-closeout.md
   required_threads:
     - THR-14
   stale_triggers:
@@ -18,9 +19,9 @@ basis:
     - standalone compatibility sources differ from the current ADR assumptions about `~/.codex/auth.json` and JWT fallback
 gates:
   pre_exec:
-    review: pending
-    contract: pending
-    revalidation: pending
+    review: passed
+    contract: failed
+    revalidation: passed
   post_exec:
     landing: pending
     closeout: pending
@@ -28,7 +29,8 @@ seam_exit_gate:
   required: true
   planned_location: S99
   status: pending
-open_remediations: []
+open_remediations:
+  - REM-001
 ---
 
 # SEAM-2 - Substrate Auth Handoff And Account-Id Provenance
@@ -63,7 +65,7 @@ open_remediations: []
   - if no valid account identity can be resolved for the selected mode, the gateway fails before the upstream call using the normal error envelope
 - **Dependencies**
   - Direct blockers:
-    - `THR-14` must publish the route contract so this seam knows the exact auth inputs and minimal header set it is serving
+    - the owned auth-handoff contract baseline is not yet written into the canonical contract path
   - Transitive blockers:
     - any later conformance work depends on this seam freezing integrated-versus-standalone ownership and failure posture
   - Direct consumers:
@@ -98,7 +100,7 @@ open_remediations: []
   - fail before the upstream call when account identity is unresolved or inconsistent
   - keep secret-bearing data out of public docs and non-secret pointer semantics only in process env
 - **Downstream decomposition context**:
-  - Why this seam is `active`, `next`, or `future`: it is `next` because auth ownership is the next critical blocker after the route contract and must publish before deterministic conformance can close the pack
+  - Why this seam is `active`, `next`, or `future`: it is `active` because the route contract is now landed and the remaining blocker is the auth-handoff contract baseline
   - Which threads matter most: `THR-14`, `THR-15`
   - What the first seam-local review should focus on: integrated-versus-standalone mode selection, field IDs, resolution precedence, provider injection ownership, and failure classification
 - **Expected seam-exit concerns**:

--- a/crates/gateway/docs/project_management/packs/active/chatgpt-codex-oauth-backend-api-responses/seam-3-codex-route-conformance-and-drift-guards.md
+++ b/crates/gateway/docs/project_management/packs/active/chatgpt-codex-oauth-backend-api-responses/seam-3-codex-route-conformance-and-drift-guards.md
@@ -2,14 +2,16 @@
 seam_id: SEAM-3
 seam_slug: codex-route-conformance-and-drift-guards
 type: conformance
-status: proposed
-execution_horizon: future
+status: exec-ready
+execution_horizon: active
 plan_version: v1
 basis:
-  currentness: provisional
+  currentness: current
   source_scope_ref: scope_brief.md
   source_scope_version: v1
-  upstream_closeouts: []
+  upstream_closeouts:
+    - governance/seam-1-closeout.md
+    - governance/seam-2-closeout.md
   required_threads:
     - THR-14
     - THR-15
@@ -19,9 +21,9 @@ basis:
     - public normalized-core behavior changes in a way that invalidates the route-local fixture expectations
 gates:
   pre_exec:
-    review: pending
-    contract: pending
-    revalidation: pending
+    review: passed
+    contract: passed
+    revalidation: passed
   post_exec:
     landing: pending
     closeout: pending
@@ -63,8 +65,7 @@ open_remediations: []
   - the suite must prove encrypted reasoning remains non-public on this route
 - **Dependencies**
   - Direct blockers:
-    - `THR-14`
-    - `THR-15`
+    - none at pre-exec; `THR-14` and `THR-15` are published and revalidated against the landed closeouts
   - Transitive blockers:
     - any auth or route ambiguity left open by earlier seams will invalidate conformance expectations
   - Direct consumers:
@@ -99,7 +100,7 @@ open_remediations: []
   - keep route-specific docs aligned with the same contract terms the tests assert
   - record clear stale triggers so future changes reopen the right seam instead of patching around drift
 - **Downstream decomposition context**:
-  - Why this seam is `active`, `next`, or `future`: it is `future` because conformance only has stable truth to encode after route and auth ownership are both published
+  - Why this seam is `active`, `next`, or `future`: it is `active` because route and auth ownership are now published, giving the conformance seam a current basis for deterministic execution planning
   - Which threads matter most: `THR-14`, `THR-15`, `THR-16`
   - What the first seam-local review should focus on: fixture boundaries, deterministic coverage strategy, integrated-versus-standalone assertions, and doc/test ownership
 - **Expected seam-exit concerns**:

--- a/crates/gateway/docs/project_management/packs/active/chatgpt-codex-oauth-backend-api-responses/seam-3-codex-route-conformance-and-drift-guards.md
+++ b/crates/gateway/docs/project_management/packs/active/chatgpt-codex-oauth-backend-api-responses/seam-3-codex-route-conformance-and-drift-guards.md
@@ -1,0 +1,110 @@
+---
+seam_id: SEAM-3
+seam_slug: codex-route-conformance-and-drift-guards
+type: conformance
+status: proposed
+execution_horizon: future
+plan_version: v1
+basis:
+  currentness: provisional
+  source_scope_ref: scope_brief.md
+  source_scope_version: v1
+  upstream_closeouts: []
+  required_threads:
+    - THR-14
+    - THR-15
+  stale_triggers:
+    - route-level request compatibility or semantic event rules change after `C-14` publishes
+    - auth-handoff ownership, field IDs, or fallback rules change after `C-15` publishes
+    - public normalized-core behavior changes in a way that invalidates the route-local fixture expectations
+gates:
+  pre_exec:
+    review: pending
+    contract: pending
+    revalidation: pending
+  post_exec:
+    landing: pending
+    closeout: pending
+seam_exit_gate:
+  required: true
+  planned_location: S99
+  status: pending
+open_remediations: []
+---
+
+# SEAM-3 - Codex Route Conformance And Drift Guards
+
+- **Goal / value**: lock the ChatGPT Codex route into deterministic regression proof so future edits cannot silently change request shaping, auth provenance, sync/stream parity, or reasoning visibility on this route.
+- **Scope**
+  - In:
+    - deterministic sync and streaming conformance for the route-local compatibility matrix
+    - regression coverage for accepted and rejected request controls, continuation synthesis/order, reasoning gating, and minimal header posture
+    - verification that integrated mode does not require gateway-local auth-file reads while standalone mode remains bounded fallback
+    - route-specific maintenance docs and evidence anchors for future revalidation
+  - Out:
+    - broad OpenAI compatibility redesign beyond this route
+    - live production monitoring or continuous external probe automation
+    - reopening route or auth contract ownership after `C-14` and `C-15` publish
+- **Primary interfaces**
+  - Inputs:
+    - `C-14`
+    - `C-15`
+    - provider and public-route test surfaces under `crates/gateway/tests/`
+    - route-facing docs under `crates/gateway/docs/`
+  - Outputs:
+    - `C-16` Codex-route conformance and drift-guard contract
+    - deterministic fixtures and regression tests
+    - route-specific maintenance guidance that names what must be revalidated when upstream behavior drifts
+- **Key invariants / rules**:
+  - route regressions should be deterministic and offline wherever possible
+  - no live network dependency is required for the core drift-guard suite
+  - the suite must prove no caller-visible control is silently stripped or degraded on the Codex route
+  - the suite must prove sync and streaming derive from the same semantic upstream event source
+  - the suite must prove encrypted reasoning remains non-public on this route
+- **Dependencies**
+  - Direct blockers:
+    - `THR-14`
+    - `THR-15`
+  - Transitive blockers:
+    - any auth or route ambiguity left open by earlier seams will invalidate conformance expectations
+  - Direct consumers:
+    - future maintenance work outside this pack
+  - Derived consumers:
+    - future operator troubleshooting, route expansion, and release validation work
+- **Touch surface**:
+  - `crates/gateway/tests/openai_responses_conformance.rs`
+  - `crates/gateway/tests/openai_shared_parity.rs`
+  - `crates/gateway/src/server/openai_conformance_test_support.rs`
+  - `crates/gateway/docs/openai-compatibility.md`
+  - `crates/gateway/docs/OAUTH_SETUP.md`
+  - `crates/gateway/docs/OAUTH_TESTING.md`
+  - conformance contract docs reserved under `docs/contracts/`
+- **Verification**:
+  - If this seam **consumes** an upstream contract, verification may depend on accepted upstream evidence.
+  - If this seam **produces** an owned contract, verification should describe the contract becoming concrete enough for seam-local planning and implementation rather than requiring the final accepted artifact to exist already.
+  - Verify the drift-guard contract is concrete enough to enumerate route-local positive and negative cases, fixture namespaces, auth-source proofs, and required documentation updates.
+  - Verify the test plan can cover sync/stream parity, `stream = true`, `store = false`, reasoning gates, continuation legality/order, and the integrated-mode no-local-read posture.
+  - Verify docs and test surfaces line up so route-specific maintenance does not depend on re-reading the ADR to know what drift matters.
+- **Canonical contract refs**:
+  - `docs/contracts/chatgpt-codex-conformance-and-drift-guard.md`
+- **Risks / unknowns**:
+  - Risk: fixture coverage misses an upstream semantic event or rejected-field edge and gives false confidence.
+  - De-risk plan: derive the suite directly from the published route and auth contracts, not from current implementation quirks alone.
+  - Risk: live upstream drift happens faster than fixtures are refreshed.
+  - De-risk plan: make revalidation triggers explicit in closeout and route docs so maintenance work knows when to revisit probe evidence.
+  - Risk: auth-source tests accidentally bake in standalone local behavior as integrated truth.
+  - De-risk plan: keep integrated-mode and standalone-mode assertions separate and contract-backed.
+- **Rollout / safety**:
+  - prefer deterministic regression coverage over ad hoc manual verification
+  - keep route-specific docs aligned with the same contract terms the tests assert
+  - record clear stale triggers so future changes reopen the right seam instead of patching around drift
+- **Downstream decomposition context**:
+  - Why this seam is `active`, `next`, or `future`: it is `future` because conformance only has stable truth to encode after route and auth ownership are both published
+  - Which threads matter most: `THR-14`, `THR-15`, `THR-16`
+  - What the first seam-local review should focus on: fixture boundaries, deterministic coverage strategy, integrated-versus-standalone assertions, and doc/test ownership
+- **Expected seam-exit concerns**:
+  - Contracts likely to publish: `C-16`
+  - Threads likely to advance: `THR-16`
+  - Review-surface areas likely to shift after landing: `R1`, `R2`, and `R3` should each gain concrete evidence anchors and stale-trigger notes
+  - Downstream seams most likely to require revalidation: future Codex-route maintenance outside this pack
+  - Accepted or published owned-contract artifacts belong here and in closeout evidence, not in pre-exec verification for the producing seam.

--- a/crates/gateway/docs/project_management/packs/active/chatgpt-codex-oauth-backend-api-responses/seam-3-codex-route-conformance-and-drift-guards.md
+++ b/crates/gateway/docs/project_management/packs/active/chatgpt-codex-oauth-backend-api-responses/seam-3-codex-route-conformance-and-drift-guards.md
@@ -2,8 +2,8 @@
 seam_id: SEAM-3
 seam_slug: codex-route-conformance-and-drift-guards
 type: conformance
-status: exec-ready
-execution_horizon: active
+status: landed
+execution_horizon: future
 plan_version: v1
 basis:
   currentness: current
@@ -25,12 +25,12 @@ gates:
     contract: passed
     revalidation: passed
   post_exec:
-    landing: pending
-    closeout: pending
+    landing: passed
+    closeout: passed
 seam_exit_gate:
   required: true
   planned_location: S99
-  status: pending
+  status: passed
 open_remediations: []
 ---
 
@@ -87,7 +87,7 @@ open_remediations: []
   - Verify the test plan can cover sync/stream parity, `stream = true`, `store = false`, reasoning gates, continuation legality/order, and the integrated-mode no-local-read posture.
   - Verify docs and test surfaces line up so route-specific maintenance does not depend on re-reading the ADR to know what drift matters.
 - **Canonical contract refs**:
-  - `docs/contracts/chatgpt-codex-conformance-and-drift-guard.md`
+  - `crates/gateway/docs/contracts/chatgpt-codex-conformance-and-drift-guard.md`
 - **Risks / unknowns**:
   - Risk: fixture coverage misses an upstream semantic event or rejected-field edge and gives false confidence.
   - De-risk plan: derive the suite directly from the published route and auth contracts, not from current implementation quirks alone.

--- a/crates/gateway/docs/project_management/packs/active/chatgpt-codex-oauth-backend-api-responses/seam_map.md
+++ b/crates/gateway/docs/project_management/packs/active/chatgpt-codex-oauth-backend-api-responses/seam_map.md
@@ -11,29 +11,29 @@ Constraint posture:
 
 ## Horizon summary
 
-- **Active seam**: `SEAM-1`
-- **Next seam**: `SEAM-2`
-- **Future seams**: `SEAM-3`
+- **Active seam**: `SEAM-2`
+- **Next seam**: none yet
+- **Future seams**: `SEAM-1`, `SEAM-3`
 
 The default v2.5 horizon policy is explicit here:
 
-- only `SEAM-1` is eligible for authoritative downstream deep planning by default
-- `SEAM-2` may later receive seam-local review and slices, but only after `SEAM-1` publishes the route contract and stream-native transport truth it depends on
+- only `SEAM-2` is eligible for authoritative downstream deep planning by default
 - `SEAM-3` remains a seam brief only and should not receive deep planning until both route and auth ownership are published
+- `SEAM-1` is landed and lives outside the forward window
 
 ## Seam roster
 
 | Seam | Horizon / state | Type | Why this is a seam | Likely value | Touch surface | Verification path |
 | --- | --- | --- | --- | --- | --- | --- |
-| `SEAM-1` `chatgpt-codex-route-contract-and-stream-native-transport` | `active` / `proposed` | `integration` | it owns the provider-side route contract, compatibility overlay, stream-native endpoint selection, and semantic event assembly as one coherent upstream boundary instead of scattering those decisions across parser, serializer, and SSE handling | ChatGPT Codex OAuth stops being a near-match and becomes a deterministic upstream transport the gateway can trust for sync, streaming, tools, images, and reasoning gating | `crates/gateway/src/providers/openai.rs`, route-facing docs under `crates/gateway/docs/`, conformance harness anchors in `crates/gateway/tests/` | seam-local review can freeze the contract, prove endpoint/header/body rules, and make sync/stream share one semantic event source |
-| `SEAM-2` `substrate-auth-handoff-and-account-id-provenance` | `next` / `proposed` | `integration` | it owns the trust boundary for `ChatGPT-Account-ID` and access-token delivery, separating integrated Substrate ownership from standalone compatibility fallback instead of leaving account identity implicit inside provider code | in-world deployments can consume delivered auth material without gateway-local host reads, while standalone mode remains a bounded fallback instead of the architectural truth | `crates/gateway/src/auth/*`, `crates/gateway/src/server/oauth_handlers.rs`, `crates/gateway/src/providers/openai.rs`, OAuth docs, and Substrate-facing contract notes | seam-local review can freeze field IDs, resolution order, failure posture, and verification surfaces for both integrated and standalone mode |
+| `SEAM-1` `chatgpt-codex-route-contract-and-stream-native-transport` | `future` / `landed` | `integration` | it owns the provider-side route contract, compatibility overlay, stream-native endpoint selection, and semantic event assembly as one coherent upstream boundary instead of scattering those decisions across parser, serializer, and SSE handling | ChatGPT Codex OAuth stops being a near-match and becomes a deterministic upstream transport the gateway can trust for sync, streaming, tools, images, and reasoning gating | `crates/gateway/src/providers/openai.rs`, route-facing docs under `crates/gateway/docs/`, conformance harness anchors in `crates/gateway/tests/` | seam-local review can freeze the contract, prove endpoint/header/body rules, and make sync/stream share one semantic event source |
+| `SEAM-2` `substrate-auth-handoff-and-account-id-provenance` | `active` / `decomposed` | `integration` | it owns the trust boundary for `ChatGPT-Account-ID` and access-token delivery, separating integrated Substrate ownership from standalone compatibility fallback instead of leaving account identity implicit inside provider code | in-world deployments can consume delivered auth material without gateway-local host reads, while standalone mode remains a bounded fallback instead of the architectural truth | `crates/gateway/src/auth/*`, `crates/gateway/src/server/oauth_handlers.rs`, `crates/gateway/src/providers/openai.rs`, OAuth docs, and Substrate-facing contract notes | seam-local review can freeze field IDs, resolution order, failure posture, and verification surfaces for both integrated and standalone mode |
 | `SEAM-3` `codex-route-conformance-and-drift-guards` | `future` / `proposed` | `conformance` | it turns the route and auth decisions into durable deterministic evidence instead of relying on ADR prose or live one-off probes | future edits fail against fixtures and route-local regressions before caller-visible drift ships | `crates/gateway/tests/*`, `crates/gateway/src/server/openai_conformance_test_support.rs`, `crates/gateway/docs/openai-compatibility.md`, and route-specific contract notes | closeout-backed tests and docs prove the route matrix, sync/stream parity, auth-source rules, and no-silent-degradation posture |
 
 ## Ordering rationale
 
-1. `SEAM-1` is active because the ADR says the pack is not extractor-ready until the dedicated route contract exists; auth and conformance both depend on that published route truth.
-2. `SEAM-2` is next because auth-handoff ownership is the next hard blocker after the route contract: integrated-mode trust boundaries must be explicit before downstream execution can claim Substrate compatibility.
-3. `SEAM-3` stays future because conformance can only lock in what `SEAM-1` and `SEAM-2` first make canonical.
+1. `SEAM-2` is active because the route contract is landed and the remaining blocker is the auth-handoff contract baseline.
+2. `SEAM-3` stays future because conformance can only lock in what route and auth ownership first make canonical.
+3. `SEAM-1` is future because it is already landed and now sits outside the forward window.
 
 ## Non-seams and pruned candidates
 

--- a/crates/gateway/docs/project_management/packs/active/chatgpt-codex-oauth-backend-api-responses/seam_map.md
+++ b/crates/gateway/docs/project_management/packs/active/chatgpt-codex-oauth-backend-api-responses/seam_map.md
@@ -11,29 +11,29 @@ Constraint posture:
 
 ## Horizon summary
 
-- **Active seam**: `SEAM-2`
+- **Active seam**: `SEAM-3`
 - **Next seam**: none yet
-- **Future seams**: `SEAM-1`, `SEAM-3`
+- **Future seams**: `SEAM-1`, `SEAM-2`
 
 The default v2.5 horizon policy is explicit here:
 
-- only `SEAM-2` is eligible for authoritative downstream deep planning by default
-- `SEAM-3` remains a seam brief only and should not receive deep planning until both route and auth ownership are published
-- `SEAM-1` is landed and lives outside the forward window
+- only `SEAM-3` is eligible for authoritative downstream deep planning by default
+- `SEAM-3` has entered active planning because both route and auth ownership are now published
+- `SEAM-1` and `SEAM-2` are landed and live outside the forward window
 
 ## Seam roster
 
 | Seam | Horizon / state | Type | Why this is a seam | Likely value | Touch surface | Verification path |
 | --- | --- | --- | --- | --- | --- | --- |
 | `SEAM-1` `chatgpt-codex-route-contract-and-stream-native-transport` | `future` / `landed` | `integration` | it owns the provider-side route contract, compatibility overlay, stream-native endpoint selection, and semantic event assembly as one coherent upstream boundary instead of scattering those decisions across parser, serializer, and SSE handling | ChatGPT Codex OAuth stops being a near-match and becomes a deterministic upstream transport the gateway can trust for sync, streaming, tools, images, and reasoning gating | `crates/gateway/src/providers/openai.rs`, route-facing docs under `crates/gateway/docs/`, conformance harness anchors in `crates/gateway/tests/` | seam-local review can freeze the contract, prove endpoint/header/body rules, and make sync/stream share one semantic event source |
-| `SEAM-2` `substrate-auth-handoff-and-account-id-provenance` | `active` / `decomposed` | `integration` | it owns the trust boundary for `ChatGPT-Account-ID` and access-token delivery, separating integrated Substrate ownership from standalone compatibility fallback instead of leaving account identity implicit inside provider code | in-world deployments can consume delivered auth material without gateway-local host reads, while standalone mode remains a bounded fallback instead of the architectural truth | `crates/gateway/src/auth/*`, `crates/gateway/src/server/oauth_handlers.rs`, `crates/gateway/src/providers/openai.rs`, OAuth docs, and Substrate-facing contract notes | seam-local review can freeze field IDs, resolution order, failure posture, and verification surfaces for both integrated and standalone mode |
-| `SEAM-3` `codex-route-conformance-and-drift-guards` | `future` / `proposed` | `conformance` | it turns the route and auth decisions into durable deterministic evidence instead of relying on ADR prose or live one-off probes | future edits fail against fixtures and route-local regressions before caller-visible drift ships | `crates/gateway/tests/*`, `crates/gateway/src/server/openai_conformance_test_support.rs`, `crates/gateway/docs/openai-compatibility.md`, and route-specific contract notes | closeout-backed tests and docs prove the route matrix, sync/stream parity, auth-source rules, and no-silent-degradation posture |
+| `SEAM-2` `substrate-auth-handoff-and-account-id-provenance` | `future` / `landed` | `integration` | it owns the trust boundary for `ChatGPT-Account-ID` and access-token delivery, separating integrated Substrate ownership from standalone compatibility fallback instead of leaving account identity implicit inside provider code | in-world deployments can consume delivered auth material without gateway-local host reads, while standalone mode remains a bounded fallback instead of the architectural truth | `crates/gateway/src/auth/*`, `crates/gateway/src/server/oauth_handlers.rs`, `crates/gateway/src/providers/openai.rs`, OAuth docs, and Substrate-facing contract notes | closeout-backed auth-handoff truth now publishes `THR-15` for downstream conformance work |
+| `SEAM-3` `codex-route-conformance-and-drift-guards` | `active` / `exec-ready` | `conformance` | it turns the route and auth decisions into durable deterministic evidence instead of relying on ADR prose or live one-off probes | future edits fail against fixtures and route-local regressions before caller-visible drift ships | `crates/gateway/tests/*`, `crates/gateway/src/server/openai_conformance_test_support.rs`, `crates/gateway/docs/openai-compatibility.md`, and route-specific contract notes | closeout-backed tests and docs prove the route matrix, sync/stream parity, auth-source rules, and no-silent-degradation posture |
 
 ## Ordering rationale
 
-1. `SEAM-2` is active because the route contract is landed and the remaining blocker is the auth-handoff contract baseline.
-2. `SEAM-3` stays future because conformance can only lock in what route and auth ownership first make canonical.
-3. `SEAM-1` is future because it is already landed and now sits outside the forward window.
+1. `SEAM-3` is active because `SEAM-1` and `SEAM-2` have both published the route and auth truth it consumes.
+2. `SEAM-3` is `exec-ready` because the conformance seam now has current upstream basis, published inbound threads, and concrete seam-local review plus slice planning.
+3. `SEAM-1` and `SEAM-2` are future because they are already landed and now sit outside the forward window.
 
 ## Non-seams and pruned candidates
 

--- a/crates/gateway/docs/project_management/packs/active/chatgpt-codex-oauth-backend-api-responses/seam_map.md
+++ b/crates/gateway/docs/project_management/packs/active/chatgpt-codex-oauth-backend-api-responses/seam_map.md
@@ -1,0 +1,44 @@
+# Seam Map - ChatGPT Codex OAuth Backend-API Responses
+
+This seam map extracts the route-specific work required to make ChatGPT Codex OAuth a first-class upstream transport without reopening the landed public OpenAI-side ingress design or the broader Substrate boundary posture.
+
+Constraint posture:
+
+- `docs/foundation/openai-side-responses-c11-contract.md`, `docs/foundation/openai-side-adapter-invariants-c12-contract.md`, and `docs/foundation/openai-side-conformance-suite-c13-contract.md` remain upstream basis and are not re-owned here
+- ADR 0010 already makes the route gap explicit: this pack does not rediscover the route problem, it turns the remaining contract, auth, and drift-guard work into governance-ready seams
+- `docs/IMPORTANT_SUBSTRATE_ALIGNMENT.md`, ADR 0005, and ADR 0006 still forbid host-local auth assumptions from becoming integrated-mode architecture
+- the remaining work is below public ingress: the route contract, auth-handoff ownership, and conformance proof for the selected ChatGPT Codex OAuth path
+
+## Horizon summary
+
+- **Active seam**: `SEAM-1`
+- **Next seam**: `SEAM-2`
+- **Future seams**: `SEAM-3`
+
+The default v2.5 horizon policy is explicit here:
+
+- only `SEAM-1` is eligible for authoritative downstream deep planning by default
+- `SEAM-2` may later receive seam-local review and slices, but only after `SEAM-1` publishes the route contract and stream-native transport truth it depends on
+- `SEAM-3` remains a seam brief only and should not receive deep planning until both route and auth ownership are published
+
+## Seam roster
+
+| Seam | Horizon / state | Type | Why this is a seam | Likely value | Touch surface | Verification path |
+| --- | --- | --- | --- | --- | --- | --- |
+| `SEAM-1` `chatgpt-codex-route-contract-and-stream-native-transport` | `active` / `proposed` | `integration` | it owns the provider-side route contract, compatibility overlay, stream-native endpoint selection, and semantic event assembly as one coherent upstream boundary instead of scattering those decisions across parser, serializer, and SSE handling | ChatGPT Codex OAuth stops being a near-match and becomes a deterministic upstream transport the gateway can trust for sync, streaming, tools, images, and reasoning gating | `crates/gateway/src/providers/openai.rs`, route-facing docs under `crates/gateway/docs/`, conformance harness anchors in `crates/gateway/tests/` | seam-local review can freeze the contract, prove endpoint/header/body rules, and make sync/stream share one semantic event source |
+| `SEAM-2` `substrate-auth-handoff-and-account-id-provenance` | `next` / `proposed` | `integration` | it owns the trust boundary for `ChatGPT-Account-ID` and access-token delivery, separating integrated Substrate ownership from standalone compatibility fallback instead of leaving account identity implicit inside provider code | in-world deployments can consume delivered auth material without gateway-local host reads, while standalone mode remains a bounded fallback instead of the architectural truth | `crates/gateway/src/auth/*`, `crates/gateway/src/server/oauth_handlers.rs`, `crates/gateway/src/providers/openai.rs`, OAuth docs, and Substrate-facing contract notes | seam-local review can freeze field IDs, resolution order, failure posture, and verification surfaces for both integrated and standalone mode |
+| `SEAM-3` `codex-route-conformance-and-drift-guards` | `future` / `proposed` | `conformance` | it turns the route and auth decisions into durable deterministic evidence instead of relying on ADR prose or live one-off probes | future edits fail against fixtures and route-local regressions before caller-visible drift ships | `crates/gateway/tests/*`, `crates/gateway/src/server/openai_conformance_test_support.rs`, `crates/gateway/docs/openai-compatibility.md`, and route-specific contract notes | closeout-backed tests and docs prove the route matrix, sync/stream parity, auth-source rules, and no-silent-degradation posture |
+
+## Ordering rationale
+
+1. `SEAM-1` is active because the ADR says the pack is not extractor-ready until the dedicated route contract exists; auth and conformance both depend on that published route truth.
+2. `SEAM-2` is next because auth-handoff ownership is the next hard blocker after the route contract: integrated-mode trust boundaries must be explicit before downstream execution can claim Substrate compatibility.
+3. `SEAM-3` stays future because conformance can only lock in what `SEAM-1` and `SEAM-2` first make canonical.
+
+## Non-seams and pruned candidates
+
+- A new public `/v1/responses` seam was rejected because the landed OpenAI-side public contract already owns that surface; this pack changes the routed provider boundary below it.
+- A separate "tool continuation" seam was rejected because continuation synthesis, ordering, and semantic event assembly are inseparable parts of the same route contract owned by `SEAM-1`.
+- A generic OAuth UI or browser-flow seam was rejected because the remaining gap is not the login UX; it is auth ownership, field provenance, and in-world delivery.
+- A broad Substrate deployment seam was rejected because this pack only needs the gateway-side auth-handoff contract and verification surfaces, not a full deployment program.
+- A live-probe or operator-smoke seam was rejected because live evidence is valuable, but the immediate gap is deterministic contract and regression truth, not ad hoc runtime testing alone.

--- a/crates/gateway/docs/project_management/packs/active/chatgpt-codex-oauth-backend-api-responses/threaded-seams/seam-1-chatgpt-codex-route-contract-and-stream-native-transport/review.md
+++ b/crates/gateway/docs/project_management/packs/active/chatgpt-codex-oauth-backend-api-responses/threaded-seams/seam-1-chatgpt-codex-route-contract-and-stream-native-transport/review.md
@@ -1,0 +1,75 @@
+---
+seam_id: SEAM-1
+review_phase: pre_exec
+execution_horizon: active
+basis_ref: seam.md#basis
+---
+# Review Bundle - SEAM-1 ChatGPT Codex Route Contract And Stream-Native Transport
+
+This artifact feeds `gates.pre_exec.review`.
+`../../review_surfaces.md` is pack orientation only.
+
+## Falsification questions
+
+- Can the route still behave as two different upstream transports by sending sync traffic to `/codex/responses` while streaming traffic stays on `/responses`, or has the plan made one endpoint and one header contract mandatory?
+- Does the owned contract now fully freeze which caller-visible controls are passed, translated, forced, or rejected, or would an implementer still have to guess about generic Responses fields, nested tool shapes, or `tool_choice = "required"`?
+- Can sync success still be reported from partial semantic output without terminal `response.completed`, or do the seam-local slices make malformed or truncated sync drains fail deterministically with `502 transport_drift`?
+
+## R1 - Routed Codex OAuth flow that must land
+
+```mermaid
+flowchart LR
+  Caller["Caller via /v1/messages, /v1/chat/completions, or /v1/responses"] --> Ingress["Thin public ingress"]
+  Ingress --> Core["GatewayRequest + normalized stream model"]
+  Core --> Matrix["Codex route compatibility matrix"]
+  Matrix --> Provider["OpenAI provider Codex route builder"]
+  Provider --> Upstream["https://chatgpt.com/backend-api/codex/responses"]
+  Upstream --> Events["Semantic SSE event family"]
+  Events --> Sync["Sync drain assembly"]
+  Events --> Stream["Normalized streaming transform"]
+  Sync --> Caller
+  Stream --> Caller
+```
+
+## R2 - Contract and implementation boundary that must remain true
+
+```mermaid
+flowchart LR
+  Req["Normalized request controls"] --> Compat["pass / translate / force / reject"]
+  Compat --> Serialize["Typed message items, flat tools, flat tool_choice"]
+  Serialize --> Headers["Authorization + ChatGPT-Account-ID + Content-Type"]
+  Headers --> Upstream["Codex responses transport"]
+  Upstream --> Events["response.output_item.*, response.content_part.*, response.output_text.*, response.function_call_arguments.*, response.completed"]
+  Events --> Assemble["Semantic output and continuation assembly"]
+  Assemble --> Out["GatewayResponse or normalized stream"]
+```
+
+## Likely mismatch hotspots
+
+- `crates/gateway/src/providers/openai.rs` currently treats sync and streaming differently at the endpoint boundary, so the first implementation slice must remove `/responses` streaming drift and enforce one Codex route.
+- The current provider path still carries extra Codex parity headers and generic Responses request shaping assumptions; the owned contract must freeze the minimal successful header set plus the explicit field allowlist/reject posture before implementation starts.
+- Sync parsing currently risks trusting the terminal envelope more than the semantic stream. The plan must keep `response.completed` as lifecycle/usage truth while making semantic event families authoritative for assembled output and tool arguments.
+- Tool continuation and reasoning handling are easy to “mostly support” while violating route truth. The slices must keep continuation synthesis provenance-based, preserve normalized-history order, and keep encrypted reasoning non-public even when the upstream stream includes it.
+
+## Pre-exec findings
+
+- The upstream OpenAI-side basis is landed and ready: `crates/gateway/docs/project_management/packs/active/openai-side-chat-completions-and-responses/governance/seam-2-closeout.md` and `.../seam-3-closeout.md` both record `seam_exit_gate.status: passed`, `promotion_readiness: ready`, and passed post-exec landing evidence.
+- ADR 0010 plus `crates/gateway/docs/IMPORTANT_SUBSTRATE_ALIGNMENT.md` are concrete enough to freeze the owned route contract without inventing post-exec truth. The seam-local plan now turns that direction into execution-grade contract, implementation, and conformance slices.
+- `crates/gateway/docs/contracts/chatgpt-codex-route-contract.md` now gives the producer seam one descriptive canonical contract path, while the slice set makes the contract concrete enough for implementation and verification without waiting on landing-time publication evidence.
+- No blocking pre-exec remediation is required. Remaining uncertainty is already captured as explicit stale triggers in `seam.md` and the slice basis metadata.
+
+## Pre-exec gate disposition
+
+- **Review gate**: `passed`
+- **Contract gate**: `passed`
+  - the owned route contract now names one endpoint, one minimal header contract, one compatibility matrix, one continuation rule set, and one semantic event assembly rule set
+  - the contract note and slice set keep auth ownership out of this seam while making the consumed `ChatGPT-Account-ID` input explicit
+- **Revalidation gate**: `passed`
+  - the seam basis is current against the landed upstream OpenAI-side public contract and conformance closeouts, and this seam has no inbound thread that must be published before execution planning can begin
+- **Opened remediations**: none
+
+## Planned seam-exit gate focus
+
+- **What must be true before downstream promotion is legal**: the canonical route contract lands, sync and streaming both use `/backend-api/codex/responses`, the minimal-header and compatibility matrix behavior is proven by deterministic verification, semantic assembly comes from the stream event family, and sync drain fails cleanly on transport drift instead of returning partial success.
+- **Which outbound contracts/threads matter most**: `C-14`, `THR-14`
+- **Which review-surface deltas would force downstream revalidation**: changes to the minimal header contract, field allowlist/reject posture, continuation synthesis/order rules, semantic event family, sync-drain failure classification, or reasoning-visibility rule

--- a/crates/gateway/docs/project_management/packs/active/chatgpt-codex-oauth-backend-api-responses/threaded-seams/seam-1-chatgpt-codex-route-contract-and-stream-native-transport/seam.md
+++ b/crates/gateway/docs/project_management/packs/active/chatgpt-codex-oauth-backend-api-responses/threaded-seams/seam-1-chatgpt-codex-route-contract-and-stream-native-transport/seam.md
@@ -1,0 +1,112 @@
+---
+seam_id: SEAM-1
+seam_slug: chatgpt-codex-route-contract-and-stream-native-transport
+status: exec-ready
+execution_horizon: active
+plan_version: v1
+basis:
+  currentness: current
+  source_seam_brief: ../../seam-1-chatgpt-codex-route-contract-and-stream-native-transport.md
+  source_scope_ref: ../../scope_brief.md
+  upstream_closeouts:
+    - crates/gateway/docs/project_management/packs/active/openai-side-chat-completions-and-responses/governance/seam-2-closeout.md
+    - crates/gateway/docs/project_management/packs/active/openai-side-chat-completions-and-responses/governance/seam-3-closeout.md
+  required_threads: []
+  stale_triggers:
+    - the live ChatGPT Codex backend changes accepted fields, required headers, or semantic event ordering relative to the 2026-04-11 probe evidence captured in ADR 0010
+    - the normalized `GatewayRequest` or stream model changes in a way that invalidates the route-local compatibility matrix or continuation provenance assumptions
+    - public OpenAI-side contracts widen or tighten supported controls in a way that forces this route to reinterpret `pass`, `translate`, `force`, or `reject`
+gates:
+  pre_exec:
+    review: passed
+    contract: passed
+    revalidation: passed
+  post_exec:
+    landing: pending
+    closeout: pending
+seam_exit_gate:
+  required: true
+  planned_location: S99
+  status: pending
+open_remediations: []
+---
+# SEAM-1 - ChatGPT Codex Route Contract And Stream-Native Transport
+
+## Seam Brief (Restated)
+
+- **Goal / value**: freeze the ChatGPT Codex OAuth provider route as one explicit upstream transport contract so the gateway can preserve caller-visible semantics while speaking the verified `backend-api/codex/responses` subset.
+- **Type**: `integration`
+- **Scope**
+  - **In**:
+    - one upstream endpoint for sync and streaming: `https://chatgpt.com/backend-api/codex/responses`
+    - the route-local `pass | translate | force | reject` compatibility matrix
+    - typed `message` item emission, image-part translation, flat function-tool serialization, and flat explicit `tool_choice`
+    - semantic stream assembly from `response.output_item.*`, `response.content_part.*`, `response.output_text.*`, and `response.function_call_arguments.*`
+    - sync-drain failure posture, including mandatory `response.completed` and `502 transport_drift` on malformed or truncated drains
+    - route-local reasoning gating, continuation synthesis rules, and the rule that encrypted reasoning stays non-public on this route
+  - **Out**:
+    - widening public ingress beyond the landed OpenAI-side contract basis
+    - built-in tools, structured-output expansion, or generic Responses fields not explicitly revalidated for this route
+    - auth-handoff ownership beyond consuming a resolved auth context and injecting `ChatGPT-Account-ID`
+- **Touch surface**:
+  - `crates/gateway/src/providers/openai.rs`
+  - `crates/gateway/src/providers/streaming.rs`
+  - `crates/gateway/src/server/openai_responses.rs`
+  - `crates/gateway/src/models/mod.rs`
+  - `crates/gateway/tests/openai_responses_conformance.rs`
+  - `crates/gateway/tests/openai_shared_parity.rs`
+  - `crates/gateway/docs/contracts/chatgpt-codex-route-contract.md`
+- **Verification**:
+  - for the owned route contract, pre-exec readiness means the endpoint/header rules, compatibility matrix, continuation legality, semantic event families, sync-drain failure behavior, and reasoning-visibility rule are concrete enough to implement without guesswork
+  - the canonical contract note and slice set must make explicit what is passed, translated, forced, or rejected for this route
+  - pre-exec readiness does not require landed implementation or post-exec publication evidence; those remain seam-exit concerns
+  - deterministic provider-focused verification anchors must be named for sync/stream parity, field rejection posture, continuation ordering, and semantic assembly from the same upstream event source
+- **Canonical contract refs**:
+  - `crates/gateway/docs/contracts/chatgpt-codex-route-contract.md`
+- **Basis posture**:
+  - **Currentness**: `current`
+  - **Upstream closeouts assumed**:
+    - `crates/gateway/docs/project_management/packs/active/openai-side-chat-completions-and-responses/governance/seam-2-closeout.md`
+    - `crates/gateway/docs/project_management/packs/active/openai-side-chat-completions-and-responses/governance/seam-3-closeout.md`
+  - **Required threads**: none
+  - **Stale triggers**:
+    - the live ChatGPT Codex backend changes accepted fields, required headers, or semantic event ordering relative to the 2026-04-11 probe evidence captured in ADR 0010
+    - the normalized `GatewayRequest` or stream model changes in a way that invalidates the route-local compatibility matrix or continuation provenance assumptions
+    - public OpenAI-side contracts widen or tighten supported controls in a way that forces this route to reinterpret `pass`, `translate`, `force`, or `reject`
+- **Threading constraints**
+  - **Upstream blockers**: none for pre-exec planning; the landed OpenAI-side public contract and conformance closeouts are already current basis for this seam
+  - **Downstream blocked seams**: `SEAM-2`, `SEAM-3`
+  - **Contracts produced**: `C-14`
+  - **Contracts consumed**: landed OpenAI-side public ingress and conformance basis from the upstream pack
+  - **Canonical contract refs**: `crates/gateway/docs/contracts/chatgpt-codex-route-contract.md`
+
+## Review bundle
+
+- `review.md` is the authoritative artifact for `gates.pre_exec.review`
+
+## Seam-exit gate plan
+
+- **Planned location**: `S99`
+- **Why this seam needs an explicit exit gate**: downstream seams must consume closeout-backed truth that the route contract actually landed, the provider uses one stream-native upstream event source for sync and streaming, and the published compatibility matrix is backed by deterministic route evidence rather than ADR prose.
+- **Expected contracts to publish**: `C-14`
+- **Expected threads to publish / advance**: `THR-14` from `defined` to `published`
+- **Likely downstream stale triggers**:
+  - `SEAM-2` if the landed minimal header contract, account-id input expectation, or continuation legality differs from plan
+  - `SEAM-3` if the landed semantic event set, sync-drain failure behavior, or reject posture differs from the planned route contract
+- **Expected closeout evidence**:
+  - the canonical route contract note at `crates/gateway/docs/contracts/chatgpt-codex-route-contract.md`
+  - landed provider implementation and tests proving endpoint parity, minimal-header behavior, compatibility classification, semantic stream assembly, and sync-drain failure rules
+  - explicit publication accounting for `THR-14`
+
+## Slice index
+
+- `S00` -> `slice-00-freeze-chatgpt-codex-route-contract.md`
+- `S1` -> `slice-1-unify-codex-route-request-shaping-and-header-contract.md`
+- `S2` -> `slice-2-deliver-stream-native-codex-transport-and-semantic-assembly.md`
+- `S3` -> `slice-3-lock-route-fixtures-and-drift-guards.md`
+- `S99` -> `slice-99-seam-exit-gate.md`
+
+## Governance pointers
+
+- Pack remediation log: `../../governance/remediation-log.md`
+- Seam closeout: `../../governance/seam-1-closeout.md`

--- a/crates/gateway/docs/project_management/packs/active/chatgpt-codex-oauth-backend-api-responses/threaded-seams/seam-1-chatgpt-codex-route-contract-and-stream-native-transport/seam.md
+++ b/crates/gateway/docs/project_management/packs/active/chatgpt-codex-oauth-backend-api-responses/threaded-seams/seam-1-chatgpt-codex-route-contract-and-stream-native-transport/seam.md
@@ -1,7 +1,7 @@
 ---
 seam_id: SEAM-1
 seam_slug: chatgpt-codex-route-contract-and-stream-native-transport
-status: exec-ready
+status: landed
 execution_horizon: active
 plan_version: v1
 basis:
@@ -22,12 +22,12 @@ gates:
     contract: passed
     revalidation: passed
   post_exec:
-    landing: pending
-    closeout: pending
+    landing: passed
+    closeout: passed
 seam_exit_gate:
   required: true
   planned_location: S99
-  status: pending
+  status: passed
 open_remediations: []
 ---
 # SEAM-1 - ChatGPT Codex Route Contract And Stream-Native Transport

--- a/crates/gateway/docs/project_management/packs/active/chatgpt-codex-oauth-backend-api-responses/threaded-seams/seam-1-chatgpt-codex-route-contract-and-stream-native-transport/slice-00-freeze-chatgpt-codex-route-contract.md
+++ b/crates/gateway/docs/project_management/packs/active/chatgpt-codex-oauth-backend-api-responses/threaded-seams/seam-1-chatgpt-codex-route-contract-and-stream-native-transport/slice-00-freeze-chatgpt-codex-route-contract.md
@@ -1,0 +1,134 @@
+---
+slice_id: S00
+seam_id: SEAM-1
+slice_kind: contract_definition
+execution_horizon: active
+status: exec-ready
+plan_version: v1
+basis:
+  currentness: current
+  basis_ref: seam.md#basis
+  stale_triggers:
+    - ADR 0010 changes the accepted-field matrix, minimal header contract, or semantic event family before implementation lands
+    - the normalized `GatewayRequest` or normalized stream model changes such that the route compatibility matrix or continuation rules must be re-planned
+gates:
+  pre_exec:
+    review: passed
+    contract: passed
+    revalidation: passed
+  post_exec:
+    landing: pending
+    closeout: pending
+threads:
+  - THR-14
+contracts_produced:
+  - C-14
+contracts_consumed: []
+open_remediations: []
+---
+### S00 - Freeze ChatGPT Codex Route Contract
+
+- **User/system value**: implementation starts from one concrete owned route contract instead of rediscovering endpoint, header, field-classification, continuation, and semantic-event rules inside provider code.
+- **Scope (in/out)**:
+  - In: freeze the canonical route contract note, the minimal successful header contract, the `pass | translate | force | reject` matrix, typed message and image translation rules, flat tool and `tool_choice` rules, continuation legality, reasoning gating, and sync-drain failure posture.
+  - Out: landed runtime evidence, downstream auth-handoff ownership, and seam-exit publication accounting.
+- **Acceptance criteria**:
+  - `crates/gateway/docs/contracts/chatgpt-codex-route-contract.md` exists and is descriptive-only
+  - the contract note names one upstream endpoint for sync and streaming, one minimal header contract, and one route-local compatibility matrix
+  - the contract note makes continuation synthesis, semantic event assembly, reasoning visibility, and `502 transport_drift` failure posture concrete enough that implementation does not need to guess
+  - the verification checklist names exact code and test anchors that later prove the route contract without relying on live upstream probes in the core regression path
+- **Dependencies**: `../../threading.md`, `../../scope_brief.md`, `../../seam-1-chatgpt-codex-route-contract-and-stream-native-transport.md`, `crates/gateway/docs/adr/0010-route-chatgpt-codex-oauth-via-backend-api-codex-responses.md`, `crates/gateway/docs/IMPORTANT_SUBSTRATE_ALIGNMENT.md`
+- **Verification**:
+  - a reviewer can answer which controls are passed, translated, forced, or rejected, how continuation synthesis is constrained, and which event families are authoritative without inspecting implementation diffs
+  - pass condition: the contract is concrete enough that `SEAM-1` satisfies `gates.pre_exec.contract` before any runtime code lands
+- **Rollout/safety**: keep the route contract narrow and explicit; do not smuggle auth ownership, rollout policy, or generic Responses expansion into this contract definition.
+- **Review surface refs**: `../../review_surfaces.md` (`R1`, `R2`) and `review.md` (`Likely mismatch hotspots`)
+
+#### Frozen canonical artifacts (this slice output)
+
+- Owned route contract: `crates/gateway/docs/contracts/chatgpt-codex-route-contract.md`
+- Normative route decision: `crates/gateway/docs/adr/0010-route-chatgpt-codex-oauth-via-backend-api-codex-responses.md`
+- Boundary guardrail: `crates/gateway/docs/IMPORTANT_SUBSTRATE_ALIGNMENT.md`
+
+#### Execution-grade freeze for the route contract
+
+- **Endpoint and header contract**:
+  - sync and streaming both target `https://chatgpt.com/backend-api/codex/responses`
+  - the minimal successful header set is:
+    - `Authorization: Bearer <access_token>`
+    - `ChatGPT-Account-ID: <account_id>`
+    - `Content-Type: application/json`
+  - extra parity headers remain out of contract unless a later route-specific ADR revalidates them
+- **Forced controls**:
+  - `stream = true`
+  - `store = false`
+  - `text.format.type = "text"`
+- **Translated controls**:
+  - bare message objects become typed `message` items
+  - image inputs remain supported only through typed `message` items with upstream `image_url` content parts
+  - flat function-tool definitions and flat explicit `tool_choice` are emitted as Codex-native wire shapes
+  - sync callers are served by draining and assembling the upstream SSE stream rather than by a separate sync upstream call
+- **Passed controls**:
+  - `reasoning.effort` with values `none | minimal | low | medium | high | xhigh`
+  - `reasoning.summary` with values `auto | concise | detailed | none`, subject to the route-local enabled predicate
+  - `parallel_tool_calls`
+  - `text.verbosity` with values `low | medium | high`
+  - `include` only as `[]` or `["reasoning.encrypted_content"]`, and only when reasoning is enabled for the latter
+  - `tool_choice = "none"` and `tool_choice = "auto"`
+- **Rejected controls**:
+  - `max_output_tokens`
+  - `metadata`
+  - `truncation`
+  - `previous_response_id`
+  - `temperature`
+  - `top_p`
+  - `user`
+  - unverified `service_tier` overrides
+  - nested Chat Completions-style tool or `tool_choice` shapes
+  - `tool_choice = "required"`
+  - `stream_options`
+- **Continuation rules**:
+  - `function_call` and `function_call_output` use flat Responses-style items
+  - a missing prior `function_call` may be synthesized only from authoritative normalized provenance for the same `call_id`
+  - synthesized `function_call` items are inserted immediately before their matching `function_call_output`
+  - orphaned `function_call_output` items without authoritative provenance reject before the upstream call
+- **Semantic assembly rules**:
+  - assembled output and tool arguments come from `response.output_item.*`, `response.content_part.*`, `response.output_text.*`, and `response.function_call_arguments.*`
+  - `response.completed` is terminal lifecycle and usage truth, not the assembled-answer source of truth
+  - sync success requires terminal `response.completed`; malformed or truncated drains fail with `502 transport_drift`
+- **Reasoning visibility rules**:
+  - reasoning is enabled only when `reasoning.effort` is present and not `"none"`
+  - non-`none` `reasoning.summary` values require reasoning to be enabled first
+  - encrypted reasoning items remain internal transport state and do not become public OpenAI-visible output on this route
+
+#### S00.T1 - Freeze The Request, Header, And Compatibility Matrix
+
+- **Outcome**: the route contract names one explicit request-shaping and header rule set for Codex OAuth.
+- **Inputs/outputs**: inputs are ADR 0010, the seam brief, current provider behavior, and normalized request shapes; outputs are the contract note plus the field-classification matrix.
+- **Thread/contract refs**: `THR-14`, `C-14`
+- **Implementation notes**: make explicit which controls are passed, translated, forced, or rejected; keep `ChatGPT-Account-ID` as a consumed input rather than an owned auth decision.
+- **Acceptance criteria**: endpoint parity, minimal headers, typed-message emission, flat tool shapes, and reject posture are all named with exact pass/fail rules.
+- **Test notes**: name positive and negative verification cases for field shaping, header emission, typed-message translation, image inputs, and deterministic rejects.
+- **Risk/rollback notes**: leaving the matrix implicit will let runtime code silently degrade unsupported controls.
+
+Checklist:
+- Implement: freeze the route matrix and name the canonical contract artifact path
+- Test: enumerate positive and negative verification cases tied to the matrix
+- Validate: confirm every supported or rejected field in ADR 0010 has an explicit disposition
+- Cleanup: remove ambiguity about headers, images, and `tool_choice`
+
+#### S00.T2 - Freeze Continuation, Semantic Assembly, And Failure Rules
+
+- **Outcome**: the route contract names one concrete continuation and semantic-event rule set for sync and streaming.
+- **Inputs/outputs**: inputs are ADR 0010, current normalized tool/stream behavior, and seam review findings; outputs are the continuation and semantic-assembly sections of the contract note.
+- **Thread/contract refs**: `THR-14`, `C-14`
+- **Implementation notes**: make continuation synthesis provenance-based, keep normalized-history order authoritative, and define `response.completed` as mandatory terminal lifecycle truth for sync drain success.
+- **Acceptance criteria**: one reviewer can explain tool continuation legality, event-family authority, reasoning suppression, and `502 transport_drift` behavior without consulting runtime code.
+- **Test notes**: name fixtures for orphaned tool results, synthesized continuation order, text/tool/mixed event streams, and truncated sync drains.
+- **Risk/rollback notes**: ambiguity here will make sync and streaming drift or expose partial output as success.
+
+Checklist:
+- Implement: freeze continuation legality, semantic event authority, and sync failure posture
+- Test: identify route fixtures and assertions for tool continuation, event ordering, and truncated drains
+- Validate: confirm reasoning stays non-public in both sync and streaming paths
+- Cleanup: remove any assumption that `response.completed.response.output` is the assembled-answer source

--- a/crates/gateway/docs/project_management/packs/active/chatgpt-codex-oauth-backend-api-responses/threaded-seams/seam-1-chatgpt-codex-route-contract-and-stream-native-transport/slice-1-unify-codex-route-request-shaping-and-header-contract.md
+++ b/crates/gateway/docs/project_management/packs/active/chatgpt-codex-oauth-backend-api-responses/threaded-seams/seam-1-chatgpt-codex-route-contract-and-stream-native-transport/slice-1-unify-codex-route-request-shaping-and-header-contract.md
@@ -1,0 +1,79 @@
+---
+slice_id: S1
+seam_id: SEAM-1
+slice_kind: implementation
+execution_horizon: active
+status: exec-ready
+plan_version: v1
+basis:
+  currentness: current
+  basis_ref: seam.md#basis
+  stale_triggers:
+    - the route contract changes the field-classification matrix, minimal header contract, or typed-message/image rules after this slice starts
+    - auth-handoff planning changes the consumed account-id input shape in a way that requires revisiting request builder assumptions
+gates:
+  pre_exec:
+    review: passed
+    contract: passed
+    revalidation: passed
+  post_exec:
+    landing: pending
+    closeout: pending
+threads:
+  - THR-14
+contracts_produced:
+  - C-14
+contracts_consumed: []
+open_remediations: []
+---
+### S1 - Unify Codex Route Request Shaping And Header Contract
+
+- **User/system value**: the provider sends one explicit ChatGPT Codex wire contract instead of a generic Responses approximation with sync/stream divergence and silent compatibility drift.
+- **Scope (in/out)**:
+  - In: unify sync and streaming on `/codex/responses`, enforce `stream = true` and `store = false`, emit only the minimal header set plus the normalized auth input, translate accepted message/image shapes into the Codex wire form, and deterministically reject unsupported caller-visible controls.
+  - Out: semantic stream assembly and sync-drain failure handling, downstream auth-handoff ownership, and whole-pack conformance ownership.
+- **Acceptance criteria**:
+  - `send_message()` and `send_message_stream()` use the same Codex endpoint when OAuth routing selects this transport
+  - the provider emits only `Authorization`, `ChatGPT-Account-ID`, and `Content-Type` unless a later ADR revalidates more headers
+  - the serializer uses typed `message` items, flat function tools, and flat explicit `tool_choice`
+  - unsupported controls reject deterministically instead of being silently stripped or degraded
+  - image inputs remain supported through typed `message` items with upstream `image_url` content parts
+- **Dependencies**: `S00`, `crates/gateway/src/providers/openai.rs`, `crates/gateway/src/models/mod.rs`, `THR-14`
+- **Verification**:
+  - positive tests prove endpoint parity, minimal headers, typed-message translation, flat tool serialization, flat explicit `tool_choice`, and accepted image-part behavior
+  - negative tests prove rejected fields and shapes fail before the upstream call
+  - pass condition: a reviewer can trace one Codex-routed request from normalized input through the provider builder without seeing generic Responses drift
+- **Rollout/safety**: keep all route-specific shaping below public ingress and do not let auth ownership bleed into this slice.
+- **Review surface refs**: `../../review_surfaces.md` (`R1`, `R2`) and `review.md` (`Likely mismatch hotspots`)
+
+#### S1.T1 - Unify Sync And Streaming On The Codex Endpoint
+
+- **Outcome**: both provider paths use one upstream transport contract.
+- **Inputs/outputs**: inputs are `C-14`, current provider request builders, and OAuth route selection; outputs are endpoint-selection and request-builder updates for sync and streaming.
+- **Thread/contract refs**: `THR-14`, `C-14`
+- **Implementation notes**: remove `/responses` streaming drift, force `stream = true`, and keep sync as a stream-drain adaptation rather than a separate upstream behavior.
+- **Acceptance criteria**: there is one route builder and one endpoint decision for Codex OAuth, shared by sync and streaming.
+- **Test notes**: add assertions for endpoint parity, forced `stream` and `store`, and route selection behavior.
+- **Risk/rollback notes**: partial endpoint unification will keep sync and streaming semantically inconsistent.
+
+Checklist:
+- Implement: route sync and streaming through one Codex endpoint builder
+- Test: assert endpoint parity and forced `stream` / `store`
+- Validate: confirm sync still uses stream drain rather than a second upstream mode
+- Cleanup: remove stale `/responses` streaming assumptions
+
+#### S1.T2 - Enforce The Minimal Header And Request-Shaping Contract
+
+- **Outcome**: request shaping matches the owned Codex route contract instead of generic Responses defaults.
+- **Inputs/outputs**: inputs are `C-14`, current serializer code, normalized request/tool/image shapes, and consumed auth context; outputs are serializer and header-emission updates plus request validation behavior.
+- **Thread/contract refs**: `THR-14`, `C-14`
+- **Implementation notes**: emit only minimal headers, use typed `message` items, keep image translation explicit, serialize flat function tools and flat explicit `tool_choice`, and reject unsupported fields/shapes deterministically.
+- **Acceptance criteria**: accepted controls preserve caller-visible semantics, rejected controls fail loudly, and no extra parity headers remain on the route by default.
+- **Test notes**: add request-shape coverage for typed messages, images, tool definitions, explicit `tool_choice`, and rejected field families.
+- **Risk/rollback notes**: if shaping stays permissive, later conformance work will need to reverse-engineer silent behavior loss.
+
+Checklist:
+- Implement: update serializer and header emission to the minimal Codex contract
+- Test: cover accepted and rejected request controls plus header assertions
+- Validate: confirm account-id consumption remains explicit but non-owning
+- Cleanup: remove generic Responses assumptions not allowed on this route

--- a/crates/gateway/docs/project_management/packs/active/chatgpt-codex-oauth-backend-api-responses/threaded-seams/seam-1-chatgpt-codex-route-contract-and-stream-native-transport/slice-2-deliver-stream-native-codex-transport-and-semantic-assembly.md
+++ b/crates/gateway/docs/project_management/packs/active/chatgpt-codex-oauth-backend-api-responses/threaded-seams/seam-1-chatgpt-codex-route-contract-and-stream-native-transport/slice-2-deliver-stream-native-codex-transport-and-semantic-assembly.md
@@ -1,0 +1,79 @@
+---
+slice_id: S2
+seam_id: SEAM-1
+slice_kind: implementation
+execution_horizon: active
+status: exec-ready
+plan_version: v1
+basis:
+  currentness: current
+  basis_ref: seam.md#basis
+  stale_triggers:
+    - the route contract changes semantic event authority, continuation legality, or sync-drain failure posture after this slice starts
+    - the normalized stream model changes such that Codex semantic assembly can no longer remain a pure transform over normalized output
+gates:
+  pre_exec:
+    review: passed
+    contract: passed
+    revalidation: passed
+  post_exec:
+    landing: pending
+    closeout: pending
+threads:
+  - THR-14
+contracts_produced:
+  - C-14
+contracts_consumed: []
+open_remediations: []
+---
+### S2 - Deliver Stream-Native Codex Transport And Semantic Assembly
+
+- **User/system value**: sync and streaming callers observe one consistent Codex route truth, with semantic output assembled from the stream event family and deterministic failures on transport drift instead of partial success.
+- **Scope (in/out)**:
+  - In: consume the upstream semantic event family for both sync and streaming, assemble text and tool-call arguments from semantic events rather than the completed envelope, enforce provenance-based continuation synthesis and ordering, and make malformed or truncated sync drains fail with `502 transport_drift`.
+  - Out: auth-handoff ownership, pack-wide regression ownership, and post-exec publication accounting.
+- **Acceptance criteria**:
+  - sync and streaming share one semantic event source and one continuation rule set
+  - sync success requires terminal `response.completed`
+  - malformed or truncated sync drains fail with the normal gateway error envelope using `class = "transport_drift"` and status `502`
+  - orphaned tool-result continuations reject before the upstream call unless authoritative normalized provenance exists
+  - encrypted reasoning items remain internal transport state and never become public OpenAI-visible output on this route
+- **Dependencies**: `S00`, `S1`, `crates/gateway/src/providers/openai.rs`, `crates/gateway/src/providers/streaming.rs`, `crates/gateway/src/server/openai_responses.rs`, `THR-14`
+- **Verification**:
+  - deterministic tests prove semantic event assembly for text-only, tool-call-only, and mixed streams
+  - negative tests prove truncated sync drains and orphaned tool-result continuations fail deterministically
+  - pass condition: a reviewer can explain sync and stream behavior without relying on `response.completed.response.output` or raw provider framing as the answer source
+- **Rollout/safety**: keep continuation repair minimal and provenance-based; do not synthesize placeholder tool metadata or surface internal reasoning content.
+- **Review surface refs**: `../../review_surfaces.md` (`R1`, `R2`) and `review.md` (`Likely mismatch hotspots`)
+
+#### S2.T1 - Assemble Output From The Semantic Event Family
+
+- **Outcome**: the provider treats semantic events as the route source of truth for sync and streaming output assembly.
+- **Inputs/outputs**: inputs are `C-14`, current SSE parsing, and normalized stream behavior; outputs are event-assembly updates for sync drain and streaming transform logic.
+- **Thread/contract refs**: `THR-14`, `C-14`
+- **Implementation notes**: make `response.output_item.*`, `response.content_part.*`, `response.output_text.*`, and `response.function_call_arguments.*` authoritative; treat `response.completed` as lifecycle and usage truth only.
+- **Acceptance criteria**: text, tool-call, and mixed streams assemble deterministically from semantic events and stay consistent between sync drain and streaming transforms.
+- **Test notes**: add fixtures and assertions for text-only, tool-only, mixed, and reasoning-bearing upstream streams.
+- **Risk/rollback notes**: if semantic assembly stays envelope-driven, sync behavior will continue to return apparently valid but partial output.
+
+Checklist:
+- Implement: update sync and streaming assembly to consume the semantic event family
+- Test: add deterministic text, tool, mixed, and reasoning-bearing fixtures
+- Validate: confirm `response.completed` is no longer treated as the assembled-answer source
+- Cleanup: remove stale envelope-trusting assumptions
+
+#### S2.T2 - Enforce Continuation Provenance And Sync-Drain Failure Rules
+
+- **Outcome**: continuation threading and sync failure posture are explicit, deterministic, and shared across route paths.
+- **Inputs/outputs**: inputs are normalized continuation history, current provider/tool state, and `C-14`; outputs are continuation-repair logic and sync failure-classification updates.
+- **Thread/contract refs**: `THR-14`, `C-14`
+- **Implementation notes**: synthesize missing `function_call` items only from authoritative normalized provenance, insert them immediately before matching `function_call_output`, preserve normalized-history order, and classify malformed sync drains as `transport_drift`.
+- **Acceptance criteria**: orphaned tool results reject cleanly, synthesized continuations never invent placeholder metadata, and malformed sync drains cannot return partial success.
+- **Test notes**: add coverage for synthesized continuation order, duplicate or orphaned tool results, truncated streams, and missing terminal completion.
+- **Risk/rollback notes**: weak continuation rules will make downstream auth and conformance planning consume ambiguous route behavior.
+
+Checklist:
+- Implement: enforce provenance-based continuation repair and sync failure classification
+- Test: cover orphaned/duplicate tool results, synthesis order, truncated drains, and missing completion
+- Validate: confirm encrypted reasoning stays non-public even when present in the upstream stream
+- Cleanup: remove placeholder synthesized tool metadata and partial-success fallbacks

--- a/crates/gateway/docs/project_management/packs/active/chatgpt-codex-oauth-backend-api-responses/threaded-seams/seam-1-chatgpt-codex-route-contract-and-stream-native-transport/slice-3-lock-route-fixtures-and-drift-guards.md
+++ b/crates/gateway/docs/project_management/packs/active/chatgpt-codex-oauth-backend-api-responses/threaded-seams/seam-1-chatgpt-codex-route-contract-and-stream-native-transport/slice-3-lock-route-fixtures-and-drift-guards.md
@@ -1,0 +1,76 @@
+---
+slice_id: S3
+seam_id: SEAM-1
+slice_kind: conformance
+execution_horizon: active
+status: exec-ready
+plan_version: v1
+basis:
+  currentness: current
+  basis_ref: seam.md#basis
+  stale_triggers:
+    - the route contract changes accepted/rejected controls, semantic event expectations, or sync-failure posture after this slice starts
+    - live upstream behavior drifts beyond the fixture-backed route evidence frozen by this slice
+gates:
+  pre_exec:
+    review: passed
+    contract: passed
+    revalidation: passed
+  post_exec:
+    landing: pending
+    closeout: pending
+threads:
+  - THR-14
+contracts_produced:
+  - C-14
+contracts_consumed: []
+open_remediations: []
+---
+### S3 - Lock Route Fixtures And Drift Guards
+
+- **User/system value**: the owned route contract is backed by deterministic evidence, so downstream seams consume named route truth instead of reverse-engineering behavior from provider code or one-off probes.
+- **Scope (in/out)**:
+  - In: add provider-focused regression coverage, fixture-backed request/stream evidence, and route-specific verification anchors for endpoint parity, request shaping, semantic assembly, sync-drain failure, continuation rules, and reasoning visibility.
+  - Out: downstream auth-handoff verification ownership and pack-wide conformance ownership that belongs to `SEAM-3`.
+- **Acceptance criteria**:
+  - deterministic tests exist for accepted versus rejected request controls, sync/stream endpoint parity, minimal headers, continuation ordering, semantic event assembly, and sync-drift failures
+  - route-specific fixtures capture the semantic event families and malformed/truncated failure cases needed by this seam
+  - the canonical route contract note and implementation tests cite each other clearly enough that `THR-14` can later publish without ADR-only evidence
+- **Dependencies**: `S00`, `S1`, `S2`, `crates/gateway/tests/openai_responses_conformance.rs`, `crates/gateway/tests/openai_shared_parity.rs`, `THR-14`
+- **Verification**:
+  - deterministic regressions prove the route matrix, event-family authority, continuation rules, and failure posture without live upstream dependence in the core path
+  - pass condition: the seam can later publish `THR-14` using named contract and fixture evidence rather than one-off probe notes
+- **Rollout/safety**: keep the regression surface route-specific and explicit; do not rely on permissive generic Responses tests to imply Codex-route correctness.
+- **Review surface refs**: `../../review_surfaces.md` (`R1`, `R2`) and `review.md` (`Planned seam-exit gate focus`)
+
+#### S3.T1 - Add Deterministic Request And Header Regression Coverage
+
+- **Outcome**: request shaping and minimal-header behavior are locked to the route contract.
+- **Inputs/outputs**: inputs are `C-14`, serializer behavior from `S1`, and current gateway test harnesses; outputs are request-shape and header-focused regressions plus any supporting fixtures.
+- **Thread/contract refs**: `THR-14`, `C-14`
+- **Implementation notes**: prove endpoint parity, minimal headers, field allowlist/reject posture, typed-message and image translation, flat tool shapes, and deterministic rejection of unsupported controls.
+- **Acceptance criteria**: tests fail if the route silently widens or degrades compatibility.
+- **Test notes**: cover accepted image inputs, rejected `stream_options`, rejected nested tool shapes, rejected `tool_choice = "required"`, and rejected generic Responses fields.
+- **Risk/rollback notes**: missing request coverage will let route drift hide behind generic provider behavior.
+
+Checklist:
+- Implement: add request and header regressions plus supporting fixtures
+- Test: cover accepted and rejected controls plus endpoint parity
+- Validate: confirm unsupported controls fail before the upstream call
+- Cleanup: keep fixture intent explicit and route-specific
+
+#### S3.T2 - Add Semantic Event, Continuation, And Drift-Failure Coverage
+
+- **Outcome**: semantic assembly, continuation legality, and sync failure posture are backed by deterministic route evidence.
+- **Inputs/outputs**: inputs are `C-14`, event assembly from `S2`, and current stream/test harnesses; outputs are semantic-stream and sync-failure regressions plus malformed-stream fixtures.
+- **Thread/contract refs**: `THR-14`, `C-14`
+- **Implementation notes**: prove event-family authority, text/tool/mixed assembly, synthesized continuation order, reasoning suppression, and `502 transport_drift` on malformed sync drains.
+- **Acceptance criteria**: the route contract can be revalidated by offline tests and fixtures rather than by ADR prose alone.
+- **Test notes**: add text-only, tool-only, mixed, reasoning-bearing, orphaned-continuation, truncated-stream, and missing-completion cases.
+- **Risk/rollback notes**: if malformed sync drains are not fixture-backed, the route will regress into partial-success behavior.
+
+Checklist:
+- Implement: add semantic-event and sync-failure regressions plus malformed-stream fixtures
+- Test: cover text, tool, mixed, reasoning-bearing, orphaned, truncated, and missing-completion cases
+- Validate: confirm deterministic evidence matches the owned contract note
+- Cleanup: keep live upstream probes out of the core regression path

--- a/crates/gateway/docs/project_management/packs/active/chatgpt-codex-oauth-backend-api-responses/threaded-seams/seam-1-chatgpt-codex-route-contract-and-stream-native-transport/slice-99-seam-exit-gate.md
+++ b/crates/gateway/docs/project_management/packs/active/chatgpt-codex-oauth-backend-api-responses/threaded-seams/seam-1-chatgpt-codex-route-contract-and-stream-native-transport/slice-99-seam-exit-gate.md
@@ -1,0 +1,80 @@
+---
+slice_id: S99
+seam_id: SEAM-1
+slice_kind: seam_exit_gate
+execution_horizon: active
+status: exec-ready
+plan_version: v1
+basis:
+  currentness: current
+  basis_ref: seam.md#basis
+  stale_triggers:
+    - closeout reveals that endpoint parity, minimal headers, semantic event authority, or sync-drain failure behavior landed differently than planned
+    - `THR-14` cannot be published because the canonical route contract or deterministic route evidence is incomplete
+    - downstream auth or conformance planning depends on route behavior that remains ambiguous at landing time
+gates:
+  pre_exec:
+    review: passed
+    contract: passed
+    revalidation: passed
+  post_exec:
+    landing: pending
+    closeout: pending
+threads:
+  - THR-14
+contracts_produced:
+  - C-14
+contracts_consumed:
+  - C-14
+open_remediations: []
+---
+### S99 - Seam Exit Gate
+
+- **User/system value**: downstream promotion consumes closeout-backed route truth instead of assuming readiness because ADR 0010 exists or because provider code appears close.
+- **Scope (in/out)**:
+  - In: capture landed evidence, canonical contract publication, `THR-14` publication state, review-surface deltas, stale triggers, remediation disposition, and a single promotion-readiness signal for downstream seams.
+  - Out: unfinished implementation work, downstream auth-handoff decisions, and whole-pack conformance ownership.
+- **Acceptance criteria**:
+  - `../../governance/seam-1-closeout.md` records this source ref, the landed evidence set, the publication decision for `THR-14`, review-surface deltas, stale triggers, remediation disposition, and one promotion-readiness statement
+  - `THR-14` advances to `published` only if the canonical route contract and deterministic provider evidence both land
+  - the closeout explicitly states whether sync and streaming now share one Codex upstream event source and whether the minimal-header contract remained intact
+  - promotion readiness is `ready` only if no blocking post-exec issue leaves `SEAM-2` or `SEAM-3` dependent on unpublished or ambiguous route behavior
+- **Dependencies**: `S00`, `S1`, `S2`, `S3`, `THR-14`, `C-14`
+- **Verification**:
+  - the closeout artifact names the canonical contract note, landed implementation anchors, regression evidence, publication state, review-surface deltas, stale triggers, and promotion-readiness decision
+  - pass condition: downstream seams can consume `THR-14` without re-reading ADR 0010 or reverse-engineering provider code
+  - failure conditions remain explicit: missing contract publication, missing deterministic evidence, ambiguous continuation behavior, or unresolved transport-drift posture
+- **Rollout/safety**: do not hide unresolved runtime behavior inside seam exit; if route truth is incomplete or ambiguous, keep promotion readiness `blocked`.
+- **Review surface refs**: `../../review_surfaces.md` (`R1`, `R2`, `R3`) and `review.md` (`Planned seam-exit gate focus`)
+
+#### S99.T1 - Capture Landed Route Evidence And Publication State
+
+- **Outcome**: closeout records the canonical evidence set for the route contract and the publication decision for `THR-14`.
+- **Inputs/outputs**: inputs are the landed outputs of `S00` through `S3`; output is the populated `../../governance/seam-1-closeout.md` record.
+- **Thread/contract refs**: `THR-14`, `C-14`
+- **Implementation notes**: name the final contract artifact, provider code anchors, deterministic test evidence, and the `THR-14` publication decision.
+- **Acceptance criteria**: a downstream reviewer can find all source-of-truth route artifacts and the exact thread-publication decision without reconstructing history.
+- **Test notes**: confirm every cited artifact exists and supports the stated publication decision.
+- **Risk/rollback notes**: weakly referenced route evidence will keep downstream seams on provisional assumptions.
+
+Checklist:
+- Implement: populate closeout with source refs, landed evidence, and thread publication accounting
+- Test: verify every cited artifact exists and supports the stated route decision
+- Validate: confirm `THR-14` publishes only when contract and regression evidence are complete
+- Cleanup: remove placeholder closeout language once real evidence is recorded
+
+#### S99.T2 - Record Deltas, Stale Triggers, And Promotion Readiness
+
+- **Outcome**: downstream seams know whether their route basis remains current after `SEAM-1` lands.
+- **Inputs/outputs**: inputs are planned-versus-landed comparison, post-exec review results, and remediation posture; outputs are closeout delta sections, stale triggers, and the final promotion-readiness statement.
+- **Thread/contract refs**: `THR-14`, `C-14`
+- **Implementation notes**: make any drift in header rules, reject posture, continuation legality, semantic event authority, or sync failure behavior explicit so downstream revalidation is intentional.
+- **Acceptance criteria**: promotion readiness ends as one clear `ready` or `blocked` statement, and any downstream stale trigger is concrete and bounded.
+- **Test notes**: compare the route contract note, landed implementation, and regression evidence before setting the closeout gate result.
+- **Risk/rollback notes**: vague delta language will force downstream seams to reverse-engineer whether their basis is stale.
+
+Checklist:
+- Implement: record deltas, stale triggers, remediation disposition, and promotion readiness
+- Test: confirm closeout covers every required seam-exit output
+- Validate: ensure downstream revalidation triggers are concrete and bounded
+- Cleanup: keep promotion blockers explicit rather than buried in prose

--- a/crates/gateway/docs/project_management/packs/active/chatgpt-codex-oauth-backend-api-responses/threaded-seams/seam-2-substrate-auth-handoff-and-account-id-provenance/review.md
+++ b/crates/gateway/docs/project_management/packs/active/chatgpt-codex-oauth-backend-api-responses/threaded-seams/seam-2-substrate-auth-handoff-and-account-id-provenance/review.md
@@ -1,0 +1,65 @@
+---
+seam_id: SEAM-2
+review_phase: pre_exec
+execution_horizon: active
+basis_ref: seam.md#basis
+---
+# Review Bundle - SEAM-2 Substrate Auth Handoff And Account-Id Provenance
+
+This artifact feeds `gates.pre_exec.review`.
+`../../review_surfaces.md` is pack orientation only.
+
+## Falsification questions
+
+- Can integrated mode still claim to be Substrate-owned if the in-world gateway runtime reads host-local auth files to recover account identity?
+- Does the plan still preserve explicit `account_id` precedence over JWT fallback, or would the provider path quietly redefine ownership by parsing whatever token shape happens to exist?
+- Does the failure posture still stop before the upstream call when no valid account identity exists, or does the seam risk deferring the error until provider-side behavior fails later?
+
+## R1 - Auth ownership flow that must land
+
+```mermaid
+flowchart LR
+  HOST["Host-side Substrate credential preflight"] --> BUNDLE["Secret-channel auth bundle"]
+  BUNDLE --> WORLD["In-world gateway runtime"]
+  WORLD --> AUTH["Resolved auth context"]
+  AUTH --> PROVIDER["Provider request builder"]
+  PROVIDER --> HEADER["ChatGPT-Account-ID injection"]
+  HEADER --> UP["backend-api/codex/responses"]
+```
+
+## R2 - Ownership and fallback boundary that must remain true
+
+```mermaid
+flowchart LR
+  AUTH["Resolved auth context"] --> OWNER["Explicit account_id"]
+  OWNER --> PROVIDER["Provider request builder"]
+  AUTH --> JWT["JWT-derived fallback"]
+  JWT --> PROVIDER
+  PROVIDER --> FAIL["Fail before upstream call when identity is unresolved"]
+```
+
+## Likely mismatch hotspots
+
+- The current token store schema still lacks a first-class `account_id` field, which makes it easy for fallback behavior to masquerade as integrated ownership.
+- The provider path already extracts account identity in `openai.rs`, but this seam must keep that as a consumer action rather than a trust-boundary decision.
+- The canonical auth-handoff contract doc is not written yet, so contract readiness remains blocked until the owner line and fallback rules are made concrete in `docs/contracts/`.
+
+## Pre-exec findings
+
+- `THR-14` is already published, so the route basis for `ChatGPT-Account-ID` injection is now current.
+- The seam now has enough input detail to plan integration and verification, but the owned canonical contract artifact is still missing from `docs/contracts/chatgpt-codex-auth-handoff-contract.md`.
+- No blocking remediation existed before this promotion run, so `REM-001` is being opened to track the missing canonical contract baseline.
+
+## Pre-exec gate disposition
+
+- **Review gate**: `passed`
+- **Contract gate**: `failed`
+  - the owned auth-handoff contract baseline is not yet written into the canonical contract path
+- **Revalidation gate**: `passed`
+- **Opened remediations**: `REM-001`
+
+## Planned seam-exit gate focus
+
+- **What must be true before downstream promotion is legal**: the canonical auth-handoff contract must exist, integrated mode must consume Substrate-delivered auth context first, JWT fallback must remain bounded, and the provider path must inject `ChatGPT-Account-ID` from resolved context without reintroducing host-local auth ownership.
+- **Which outbound contracts/threads matter most**: `C-15`, `THR-15`
+- **Which review-surface deltas would force downstream revalidation**: changes to owner-line precedence, fallback behavior, auth-field identifiers, delivery posture, or provider injection order

--- a/crates/gateway/docs/project_management/packs/active/chatgpt-codex-oauth-backend-api-responses/threaded-seams/seam-2-substrate-auth-handoff-and-account-id-provenance/review.md
+++ b/crates/gateway/docs/project_management/packs/active/chatgpt-codex-oauth-backend-api-responses/threaded-seams/seam-2-substrate-auth-handoff-and-account-id-provenance/review.md
@@ -42,21 +42,20 @@ flowchart LR
 
 - The current token store schema still lacks a first-class `account_id` field, which makes it easy for fallback behavior to masquerade as integrated ownership.
 - The provider path already extracts account identity in `openai.rs`, but this seam must keep that as a consumer action rather than a trust-boundary decision.
-- The canonical auth-handoff contract doc is not written yet, so contract readiness remains blocked until the owner line and fallback rules are made concrete in `docs/contracts/`.
+- The current provider path still derives `ChatGPT-Account-ID` from JWT fallback only, so execution must land a resolved-auth-context carrier before the owner line is true in code.
 
 ## Pre-exec findings
 
-- `THR-14` is already published, so the route basis for `ChatGPT-Account-ID` injection is now current.
-- The seam now has enough input detail to plan integration and verification, but the owned canonical contract artifact is still missing from `docs/contracts/chatgpt-codex-auth-handoff-contract.md`.
-- No blocking remediation existed before this promotion run, so `REM-001` is being opened to track the missing canonical contract baseline.
+- `THR-14` was published by the seam-1 closeout and is now revalidated here against the landed route contract, the seam-1 closeout seam-exit record, and the current provider/auth evidence anchors.
+- The owned canonical contract artifact now exists at `crates/gateway/docs/contracts/chatgpt-codex-auth-handoff-contract.md`, and `S00` records the integrated owner line, field identifiers, fallback order, and execution checklist concretely enough for implementation.
+- `REM-001` remains open only as a landing-phase owner checklist for the S1/S2/S3 code and verification work that must publish `THR-15`; it no longer blocks `status: exec-ready`.
 
 ## Pre-exec gate disposition
 
 - **Review gate**: `passed`
-- **Contract gate**: `failed`
-  - the owned auth-handoff contract baseline is not yet written into the canonical contract path
-- **Revalidation gate**: `passed`
-- **Opened remediations**: `REM-001`
+- **Contract gate**: `passed`; the owned auth-handoff baseline and execution checklist are now concrete in the canonical contract note plus `S00`
+- **Revalidation gate**: `passed`; the seam was rechecked against `../../governance/seam-1-closeout.md`, `crates/gateway/docs/contracts/chatgpt-codex-route-contract.md`, `crates/gateway/src/providers/openai.rs`, `crates/gateway/src/auth/token_store.rs`, and `crates/gateway/src/server/mod.rs`
+- **Open remediations**: `REM-001` remains open for landing and thread publication only
 
 ## Planned seam-exit gate focus
 

--- a/crates/gateway/docs/project_management/packs/active/chatgpt-codex-oauth-backend-api-responses/threaded-seams/seam-2-substrate-auth-handoff-and-account-id-provenance/seam.md
+++ b/crates/gateway/docs/project_management/packs/active/chatgpt-codex-oauth-backend-api-responses/threaded-seams/seam-2-substrate-auth-handoff-and-account-id-provenance/seam.md
@@ -1,7 +1,7 @@
 ---
 seam_id: SEAM-2
 seam_slug: substrate-auth-handoff-and-account-id-provenance
-status: decomposed
+status: exec-ready
 execution_horizon: active
 plan_version: v1
 basis:
@@ -19,7 +19,7 @@ basis:
 gates:
   pre_exec:
     review: passed
-    contract: failed
+    contract: passed
     revalidation: passed
   post_exec:
     landing: pending
@@ -53,16 +53,17 @@ open_remediations:
   - `crates/gateway/src/auth/token_store.rs`
   - `crates/gateway/src/server/oauth_handlers.rs`
   - `crates/gateway/src/providers/openai.rs`
+  - `crates/gateway/src/server/mod.rs`
   - `crates/gateway/docs/OAUTH_SETUP.md`
   - `crates/gateway/docs/OAUTH_TESTING.md`
-  - `docs/contracts/chatgpt-codex-auth-handoff-contract.md`
+  - `crates/gateway/docs/contracts/chatgpt-codex-auth-handoff-contract.md`
 - **Verification**:
   - For owned contracts, describe what must be concrete in seam-local planning before execution.
   - Reserve accepted or published contract artifact evidence for seam exit and closeout.
-  - The canonical contract text for an owned contract must live in `docs/contracts/chatgpt-codex-auth-handoff-contract.md`; seam-local planning may reference that path, but may not treat planning-pack docs as canonical.
+  - The canonical contract text for an owned contract must live in `crates/gateway/docs/contracts/chatgpt-codex-auth-handoff-contract.md`; seam-local planning may reference that path, but may not treat planning-pack docs as canonical.
   - Verify the owner line, field precedence, delivery posture, and failure envelope without depending on gateway-local auth-file reads inside the in-world runtime.
 - **Basis posture**:
-  - **Currentness**: `current`
+  - **Currentness**: `current` (revalidated against `THR-14` publication and the landed seam-1 closeout-backed route contract)
   - **Upstream closeouts assumed**: `../../governance/seam-1-closeout.md`
   - **Required threads**: `THR-14`
   - **Stale triggers**:
@@ -70,7 +71,7 @@ open_remediations:
     - Substrate delivery posture changes for auth bundles, secret-channel transport, or in-world consumption
     - standalone compatibility sources differ from the current ADR assumptions about `~/.codex/auth.json` and JWT fallback
 - **Threading constraints**
-  - **Upstream blockers**: `THR-14` is published and provides the route basis this seam consumes
+  - **Upstream blockers**: none at pre-exec; `THR-14` is published by `SEAM-1` and has now been revalidated against the landed route contract and current provider/auth evidence anchors
   - **Downstream blocked seams**: `SEAM-3`
   - **Contracts produced**: `C-15`
   - **Contracts consumed**: `C-14`

--- a/crates/gateway/docs/project_management/packs/active/chatgpt-codex-oauth-backend-api-responses/threaded-seams/seam-2-substrate-auth-handoff-and-account-id-provenance/seam.md
+++ b/crates/gateway/docs/project_management/packs/active/chatgpt-codex-oauth-backend-api-responses/threaded-seams/seam-2-substrate-auth-handoff-and-account-id-provenance/seam.md
@@ -1,8 +1,8 @@
 ---
 seam_id: SEAM-2
 seam_slug: substrate-auth-handoff-and-account-id-provenance
-status: exec-ready
-execution_horizon: active
+status: landed
+execution_horizon: future
 plan_version: v1
 basis:
   currentness: current
@@ -12,6 +12,7 @@ basis:
     - ../../governance/seam-1-closeout.md
   required_threads:
     - THR-14
+    - THR-15
   stale_triggers:
     - the route contract changes the required header contract or the exact auth-context fields the provider path consumes
     - Substrate delivery posture changes for auth bundles, secret-channel transport, or in-world consumption
@@ -22,14 +23,13 @@ gates:
     contract: passed
     revalidation: passed
   post_exec:
-    landing: pending
-    closeout: pending
+    landing: passed
+    closeout: passed
 seam_exit_gate:
   required: true
   planned_location: S99
-  status: pending
-open_remediations:
-  - REM-001
+  status: passed
+open_remediations: []
 ---
 # SEAM-2 - Substrate Auth Handoff And Account-Id Provenance
 
@@ -72,7 +72,7 @@ open_remediations:
     - standalone compatibility sources differ from the current ADR assumptions about `~/.codex/auth.json` and JWT fallback
 - **Threading constraints**
   - **Upstream blockers**: none at pre-exec; `THR-14` is published by `SEAM-1` and has now been revalidated against the landed route contract and current provider/auth evidence anchors
-  - **Downstream blocked seams**: `SEAM-3`
+  - **Downstream blocked seams**: none in this pack; `THR-15` is now published and consumed by the landed `SEAM-3` closeout-backed conformance baseline
   - **Contracts produced**: `C-15`
   - **Contracts consumed**: `C-14`
 

--- a/crates/gateway/docs/project_management/packs/active/chatgpt-codex-oauth-backend-api-responses/threaded-seams/seam-2-substrate-auth-handoff-and-account-id-provenance/seam.md
+++ b/crates/gateway/docs/project_management/packs/active/chatgpt-codex-oauth-backend-api-responses/threaded-seams/seam-2-substrate-auth-handoff-and-account-id-provenance/seam.md
@@ -1,0 +1,102 @@
+---
+seam_id: SEAM-2
+seam_slug: substrate-auth-handoff-and-account-id-provenance
+status: decomposed
+execution_horizon: active
+plan_version: v1
+basis:
+  currentness: current
+  source_seam_brief: ../../seam-2-substrate-auth-handoff-and-account-id-provenance.md
+  source_scope_ref: ../../scope_brief.md
+  upstream_closeouts:
+    - ../../governance/seam-1-closeout.md
+  required_threads:
+    - THR-14
+  stale_triggers:
+    - the route contract changes the required header contract or the exact auth-context fields the provider path consumes
+    - Substrate delivery posture changes for auth bundles, secret-channel transport, or in-world consumption
+    - standalone compatibility sources differ from the current ADR assumptions about `~/.codex/auth.json` and JWT fallback
+gates:
+  pre_exec:
+    review: passed
+    contract: failed
+    revalidation: passed
+  post_exec:
+    landing: pending
+    closeout: pending
+seam_exit_gate:
+  required: true
+  planned_location: S99
+  status: pending
+open_remediations:
+  - REM-001
+---
+# SEAM-2 - Substrate Auth Handoff And Account-Id Provenance
+
+## Seam Brief (Restated)
+
+- **Goal / value**: freeze the integrated-versus-standalone auth owner line so `ChatGPT-Account-ID` and access-token delivery are explicit, policy-compatible, and reviewable instead of being inferred from provider-local token parsing.
+- **Type**: `integration`
+- **Scope**
+  - In:
+    - Substrate-owned integrated-mode auth delivery and account-id ownership
+    - standalone compatibility posture and its bounded fallback order
+    - the closed `cli:codex` auth field set and gateway-consumed field identifiers
+    - gateway auth-context resolution and pre-upstream failure behavior when no valid account identity exists
+    - provider request-builder injection of `ChatGPT-Account-ID` from resolved auth context
+  - Out:
+    - redesigning the OAuth browser flow or token-refresh UX
+    - turning standalone local auth files into integrated-mode architecture
+    - broad Substrate deployment planning beyond the gateway-side auth-handoff boundary this route needs
+- **Touch surface**:
+  - `crates/gateway/src/auth/oauth.rs`
+  - `crates/gateway/src/auth/token_store.rs`
+  - `crates/gateway/src/server/oauth_handlers.rs`
+  - `crates/gateway/src/providers/openai.rs`
+  - `crates/gateway/docs/OAUTH_SETUP.md`
+  - `crates/gateway/docs/OAUTH_TESTING.md`
+  - `docs/contracts/chatgpt-codex-auth-handoff-contract.md`
+- **Verification**:
+  - For owned contracts, describe what must be concrete in seam-local planning before execution.
+  - Reserve accepted or published contract artifact evidence for seam exit and closeout.
+  - The canonical contract text for an owned contract must live in `docs/contracts/chatgpt-codex-auth-handoff-contract.md`; seam-local planning may reference that path, but may not treat planning-pack docs as canonical.
+  - Verify the owner line, field precedence, delivery posture, and failure envelope without depending on gateway-local auth-file reads inside the in-world runtime.
+- **Basis posture**:
+  - **Currentness**: `current`
+  - **Upstream closeouts assumed**: `../../governance/seam-1-closeout.md`
+  - **Required threads**: `THR-14`
+  - **Stale triggers**:
+    - the route contract changes the required header contract or the exact auth-context fields the provider path consumes
+    - Substrate delivery posture changes for auth bundles, secret-channel transport, or in-world consumption
+    - standalone compatibility sources differ from the current ADR assumptions about `~/.codex/auth.json` and JWT fallback
+- **Threading constraints**
+  - **Upstream blockers**: `THR-14` is published and provides the route basis this seam consumes
+  - **Downstream blocked seams**: `SEAM-3`
+  - **Contracts produced**: `C-15`
+  - **Contracts consumed**: `C-14`
+
+## Review bundle
+
+- `review.md` is the authoritative artifact for `gates.pre_exec.review`
+
+## Seam-exit gate plan
+
+- **Planned location**: `S99`
+- **Why this seam needs an explicit exit gate**: downstream work must consume a closeout-backed auth owner line, explicit fallback posture, and a canonical contract record rather than inferring ownership from provider code.
+- **Expected contracts to publish**: `C-15`
+- **Expected threads to publish / advance**: `THR-15`
+- **Likely downstream stale triggers**: changes to the owner line, field precedence, fallback rules, delivery posture, or provider injection contract
+- **Expected closeout evidence**: the canonical auth-handoff contract note, resolved owner-line verification, provider injection proof, and a final `THR-15` publication decision
+
+## Slice index
+
+- `S00` -> `slice-00-freeze-auth-handoff-contract.md`
+- `S1` -> `slice-1-resolve-auth-context-and-owner-line.md`
+- `S2` -> `slice-2-inject-account-id-and-bounded-fallback.md`
+- `S3` -> `slice-3-verify-auth-source-and-failure-posture.md`
+- `S99` -> `slice-99-seam-exit-gate.md`
+
+## Governance pointers
+
+- Pack remediation log: `../../governance/remediation-log.md`
+- Seam closeout: `../../governance/seam-2-closeout.md`

--- a/crates/gateway/docs/project_management/packs/active/chatgpt-codex-oauth-backend-api-responses/threaded-seams/seam-2-substrate-auth-handoff-and-account-id-provenance/slice-00-freeze-auth-handoff-contract.md
+++ b/crates/gateway/docs/project_management/packs/active/chatgpt-codex-oauth-backend-api-responses/threaded-seams/seam-2-substrate-auth-handoff-and-account-id-provenance/slice-00-freeze-auth-handoff-contract.md
@@ -3,7 +3,7 @@ slice_id: S00
 seam_id: SEAM-2
 slice_kind: contract_definition
 execution_horizon: active
-status: decomposed
+status: exec-ready
 plan_version: v1
 basis:
   currentness: current
@@ -14,7 +14,7 @@ basis:
 gates:
   pre_exec:
     review: passed
-    contract: failed
+    contract: passed
     revalidation: passed
   post_exec:
     landing: pending
@@ -35,9 +35,10 @@ open_remediations:
   - In: freeze the canonical auth-handoff contract note, the integrated-mode owner line, the standalone fallback path, the required field identifiers, and the pre-upstream failure posture.
   - Out: final published seam-exit evidence, route contract changes, and generic OAuth UX redesign.
 - **Acceptance criteria**:
-  - `docs/contracts/chatgpt-codex-auth-handoff-contract.md` exists and is descriptive-only
+  - `crates/gateway/docs/contracts/chatgpt-codex-auth-handoff-contract.md` exists and is descriptive-only
   - the contract names the integrated-mode owner line, the bounded standalone fallback, explicit `account_id` precedence, and the unresolved-identity failure envelope
   - the contract note is concrete enough that seam-local implementation does not need to guess where auth ownership begins or ends
+  - the verification checklist names the exact code and test anchors that later prove the owner line without making gateway-local token persistence authoritative for integrated mode
 - **Dependencies**: `../../threading.md`, `../../scope_brief.md`, `../../seam-2-substrate-auth-handoff-and-account-id-provenance.md`, `../../governance/seam-1-closeout.md`, `docs/IMPORTANT_SUBSTRATE_ALIGNMENT.md`
 - **Verification**:
   - a reviewer can explain the owner line, fallback order, and failure posture without inspecting implementation diffs
@@ -47,29 +48,37 @@ open_remediations:
 
 #### Frozen canonical artifacts (this slice output)
 
-- Owned auth-handoff contract: `docs/contracts/chatgpt-codex-auth-handoff-contract.md`
+- Owned auth-handoff contract: `crates/gateway/docs/contracts/chatgpt-codex-auth-handoff-contract.md`
 - Route contract basis: `docs/contracts/chatgpt-codex-route-contract.md`
 - Boundary guardrail: `docs/IMPORTANT_SUBSTRATE_ALIGNMENT.md`
 
 #### Execution-grade freeze for the auth handoff
 
-- **Owner line and precedence**:
-  - integrated mode consumes Substrate-delivered auth context first
-  - explicit `account_id` is the first resolved source
-  - JWT-derived `account_id` is a bounded fallback only when explicit `account_id` is absent
+- **Integrated-mode owner line**:
+  - Substrate owns host credential reads, auth-state validation, and host-to-world delivery for ChatGPT Codex auth material
+  - the gateway consumes resolved auth context and does not become the owner of host credential reads or trust-boundary decisions
+  - secret-bearing delivery remains an auth bundle or equivalent secret channel, with env vars limited to non-secret pointer semantics
+- **Field identifiers and precedence**:
+  - the canonical integrated-mode field identifiers are `SUBSTRATE_LLM_BACKEND_AUTH_CLI_CODEX_ACCOUNT_ID` and `SUBSTRATE_LLM_BACKEND_AUTH_CLI_CODEX_ACCESS_TOKEN`
+  - integrated mode resolves explicit `account_id` first, then JWT-derived fallback from the same delivered access token, then fails before upstream
+  - standalone mode resolves explicit `account_id` from local Codex auth state first, then JWT-derived fallback from the same local OAuth access token, then fails before upstream
+  - if explicit and JWT-derived account ids disagree, the explicit value wins
 - **Failure posture**:
   - if no valid account identity is available, the gateway fails before the upstream call using the normal error envelope
   - host-local auth-file reads are not a required integrated-mode trust input
 - **Provider consumption**:
   - the provider request builder injects `ChatGPT-Account-ID` from resolved auth context
   - the provider path does not become the owner of host credential reads
+  - the current JWT-only helper in `crates/gateway/src/providers/openai.rs` is a bounded fallback implementation detail, not the owner-line contract
 
 #### S00.T1 - Freeze The Owner Line And Field Precedence
 
 - **Outcome**: the seam contract names one explicit auth owner line for integrated and standalone mode.
 - **Inputs/outputs**: inputs are the route contract basis, ADR 0010 auth assumptions, and current gateway auth surfaces; outputs are the auth-handoff contract note and the owner-line decision record.
 - **Thread/contract refs**: `THR-15`, `C-15`
+- **Implementation notes**: keep integrated delivery tied to the Substrate-owned handoff fields and keep standalone local auth state subordinate to that owner line.
 - **Acceptance criteria**: one reviewer can explain which source wins for `account_id`, which fallback is bounded, and which failures stop the request before the upstream call.
+- **Test notes**: name positive and negative verification cases for explicit-over-JWT precedence, bounded fallback, and no-upstream-call failure behavior.
 
 #### S00.T2 - Freeze The Failure Envelope And Verification Checklist
 
@@ -77,3 +86,13 @@ open_remediations:
 - **Inputs/outputs**: inputs are the resolved owner line and existing provider/auth code paths; outputs are the failure envelope and verification checklist.
 - **Thread/contract refs**: `THR-15`, `C-15`
 - **Acceptance criteria**: unresolved identity fails before upstream, and the verification checklist names the exact code and test anchors that will prove it.
+
+Checklist:
+- Implement: add a resolved auth-context carrier that surfaces explicit `account_id` plus access token for the selected mode without making gateway-local persistence authoritative for integrated operation
+- Implement: update `crates/gateway/src/providers/openai.rs` so the Codex request builder prefers explicit `account_id`, uses JWT only as bounded fallback, and fails before upstream when identity is unresolved
+- Test: add `codex_oauth_request_builder_prefers_explicit_account_id_over_jwt_fallback` in `crates/gateway/src/providers/openai.rs`
+- Test: add `codex_oauth_request_builder_uses_jwt_fallback_only_when_explicit_account_id_is_absent` in `crates/gateway/src/providers/openai.rs`
+- Test: add `codex_oauth_request_builder_fails_before_upstream_when_account_id_is_unresolvable` in `crates/gateway/src/providers/openai.rs`
+- Validate: keep auth-failure classification aligned with `crates/gateway/src/server/mod.rs` so unresolved identity stays in the normal `auth` error envelope
+- Validate: update `crates/gateway/docs/OAUTH_SETUP.md` and `crates/gateway/docs/OAUTH_TESTING.md` so standalone local OAuth/token material is documented as compatibility-only, not the integrated trust boundary
+- Publish when landed: record the landed owner-line evidence in `../../governance/seam-2-closeout.md` and advance `THR-15` only after the canonical contract, provider wiring, and verification surfaces all land

--- a/crates/gateway/docs/project_management/packs/active/chatgpt-codex-oauth-backend-api-responses/threaded-seams/seam-2-substrate-auth-handoff-and-account-id-provenance/slice-00-freeze-auth-handoff-contract.md
+++ b/crates/gateway/docs/project_management/packs/active/chatgpt-codex-oauth-backend-api-responses/threaded-seams/seam-2-substrate-auth-handoff-and-account-id-provenance/slice-00-freeze-auth-handoff-contract.md
@@ -1,0 +1,79 @@
+---
+slice_id: S00
+seam_id: SEAM-2
+slice_kind: contract_definition
+execution_horizon: active
+status: decomposed
+plan_version: v1
+basis:
+  currentness: current
+  basis_ref: seam.md#basis
+  stale_triggers:
+    - the route contract changes the minimal header contract, account-id input shape, or auth-context field expectations
+    - Substrate delivery posture changes for auth bundles or in-world secret consumption
+gates:
+  pre_exec:
+    review: passed
+    contract: failed
+    revalidation: passed
+  post_exec:
+    landing: pending
+    closeout: pending
+threads:
+  - THR-15
+contracts_produced:
+  - C-15
+contracts_consumed:
+  - C-14
+open_remediations:
+  - REM-001
+---
+### S00 - Freeze Auth Handoff Contract
+
+- **User/system value**: implementation starts from one explicit auth owner line instead of rediscovering provenance rules inside provider code or auth helpers.
+- **Scope (in/out)**:
+  - In: freeze the canonical auth-handoff contract note, the integrated-mode owner line, the standalone fallback path, the required field identifiers, and the pre-upstream failure posture.
+  - Out: final published seam-exit evidence, route contract changes, and generic OAuth UX redesign.
+- **Acceptance criteria**:
+  - `docs/contracts/chatgpt-codex-auth-handoff-contract.md` exists and is descriptive-only
+  - the contract names the integrated-mode owner line, the bounded standalone fallback, explicit `account_id` precedence, and the unresolved-identity failure envelope
+  - the contract note is concrete enough that seam-local implementation does not need to guess where auth ownership begins or ends
+- **Dependencies**: `../../threading.md`, `../../scope_brief.md`, `../../seam-2-substrate-auth-handoff-and-account-id-provenance.md`, `../../governance/seam-1-closeout.md`, `docs/IMPORTANT_SUBSTRATE_ALIGNMENT.md`
+- **Verification**:
+  - a reviewer can explain the owner line, fallback order, and failure posture without inspecting implementation diffs
+  - pass condition: the contract is concrete enough that `SEAM-2` can be planned and implemented without ambiguity
+- **Rollout/safety**: keep the contract narrow and explicit; do not hide auth ownership inside token parsing or gateway-local persistence.
+- **Review surface refs**: `../../review_surfaces.md` (`R3`) and `review.md` (`Likely mismatch hotspots`)
+
+#### Frozen canonical artifacts (this slice output)
+
+- Owned auth-handoff contract: `docs/contracts/chatgpt-codex-auth-handoff-contract.md`
+- Route contract basis: `docs/contracts/chatgpt-codex-route-contract.md`
+- Boundary guardrail: `docs/IMPORTANT_SUBSTRATE_ALIGNMENT.md`
+
+#### Execution-grade freeze for the auth handoff
+
+- **Owner line and precedence**:
+  - integrated mode consumes Substrate-delivered auth context first
+  - explicit `account_id` is the first resolved source
+  - JWT-derived `account_id` is a bounded fallback only when explicit `account_id` is absent
+- **Failure posture**:
+  - if no valid account identity is available, the gateway fails before the upstream call using the normal error envelope
+  - host-local auth-file reads are not a required integrated-mode trust input
+- **Provider consumption**:
+  - the provider request builder injects `ChatGPT-Account-ID` from resolved auth context
+  - the provider path does not become the owner of host credential reads
+
+#### S00.T1 - Freeze The Owner Line And Field Precedence
+
+- **Outcome**: the seam contract names one explicit auth owner line for integrated and standalone mode.
+- **Inputs/outputs**: inputs are the route contract basis, ADR 0010 auth assumptions, and current gateway auth surfaces; outputs are the auth-handoff contract note and the owner-line decision record.
+- **Thread/contract refs**: `THR-15`, `C-15`
+- **Acceptance criteria**: one reviewer can explain which source wins for `account_id`, which fallback is bounded, and which failures stop the request before the upstream call.
+
+#### S00.T2 - Freeze The Failure Envelope And Verification Checklist
+
+- **Outcome**: the seam contract names the failure posture and the seam-local verification anchors.
+- **Inputs/outputs**: inputs are the resolved owner line and existing provider/auth code paths; outputs are the failure envelope and verification checklist.
+- **Thread/contract refs**: `THR-15`, `C-15`
+- **Acceptance criteria**: unresolved identity fails before upstream, and the verification checklist names the exact code and test anchors that will prove it.

--- a/crates/gateway/docs/project_management/packs/active/chatgpt-codex-oauth-backend-api-responses/threaded-seams/seam-2-substrate-auth-handoff-and-account-id-provenance/slice-1-resolve-auth-context-and-owner-line.md
+++ b/crates/gateway/docs/project_management/packs/active/chatgpt-codex-oauth-backend-api-responses/threaded-seams/seam-2-substrate-auth-handoff-and-account-id-provenance/slice-1-resolve-auth-context-and-owner-line.md
@@ -1,0 +1,46 @@
+---
+slice_id: S1
+seam_id: SEAM-2
+slice_kind: implementation
+execution_horizon: active
+status: decomposed
+plan_version: v1
+basis:
+  currentness: current
+  basis_ref: seam.md#basis
+  stale_triggers:
+    - the route contract changes the minimal header contract or the exact auth-context fields the provider path consumes
+    - Substrate delivery posture changes for auth bundles, secret-channel transport, or in-world consumption
+gates:
+  pre_exec:
+    review: pending
+    contract: pending
+    revalidation: pending
+  post_exec:
+    landing: pending
+    closeout: pending
+threads:
+  - THR-14
+  - THR-15
+contracts_produced: []
+contracts_consumed:
+  - C-14
+  - C-15
+open_remediations: []
+---
+### S1 - Resolve Auth Context And Owner Line
+
+- **User/system value**: the gateway has one explicit auth-resolution path instead of a loose mix of token parsing and ad hoc fallback logic.
+- **Scope (in/out)**:
+  - In: resolve Substrate-delivered auth context, preserve explicit `account_id` precedence, and keep gateway-local persistence out of the integrated trust boundary.
+  - Out: provider header emission, conformance coverage, and seam-exit publication accounting.
+- **Acceptance criteria**:
+  - integrated-mode auth context can be resolved without host-local auth-file reads
+  - explicit `account_id` remains the first source of truth
+  - fallback behavior stays bounded and reviewable
+- **Dependencies**: `S00`, `crates/gateway/src/auth/*`, `crates/gateway/src/server/oauth_handlers.rs`, `THR-15`
+- **Verification**:
+  - positive checks prove integrated and standalone mode are distinguishable
+  - negative checks prove unresolved identity fails before the upstream call
+- **Rollout/safety**: keep owner-line logic below the provider boundary and out of public ingress.
+- **Review surface refs**: `../../review_surfaces.md` (`R3`) and `review.md`

--- a/crates/gateway/docs/project_management/packs/active/chatgpt-codex-oauth-backend-api-responses/threaded-seams/seam-2-substrate-auth-handoff-and-account-id-provenance/slice-1-resolve-auth-context-and-owner-line.md
+++ b/crates/gateway/docs/project_management/packs/active/chatgpt-codex-oauth-backend-api-responses/threaded-seams/seam-2-substrate-auth-handoff-and-account-id-provenance/slice-1-resolve-auth-context-and-owner-line.md
@@ -3,7 +3,7 @@ slice_id: S1
 seam_id: SEAM-2
 slice_kind: implementation
 execution_horizon: active
-status: decomposed
+status: exec-ready
 plan_version: v1
 basis:
   currentness: current
@@ -13,9 +13,9 @@ basis:
     - Substrate delivery posture changes for auth bundles, secret-channel transport, or in-world consumption
 gates:
   pre_exec:
-    review: pending
-    contract: pending
-    revalidation: pending
+    review: passed
+    contract: passed
+    revalidation: passed
   post_exec:
     landing: pending
     closeout: pending

--- a/crates/gateway/docs/project_management/packs/active/chatgpt-codex-oauth-backend-api-responses/threaded-seams/seam-2-substrate-auth-handoff-and-account-id-provenance/slice-2-inject-account-id-and-bounded-fallback.md
+++ b/crates/gateway/docs/project_management/packs/active/chatgpt-codex-oauth-backend-api-responses/threaded-seams/seam-2-substrate-auth-handoff-and-account-id-provenance/slice-2-inject-account-id-and-bounded-fallback.md
@@ -3,7 +3,7 @@ slice_id: S2
 seam_id: SEAM-2
 slice_kind: implementation
 execution_horizon: active
-status: decomposed
+status: exec-ready
 plan_version: v1
 basis:
   currentness: current
@@ -13,9 +13,9 @@ basis:
     - auth-context resolution changes in a way that alters account-id precedence
 gates:
   pre_exec:
-    review: pending
-    contract: pending
-    revalidation: pending
+    review: passed
+    contract: passed
+    revalidation: passed
   post_exec:
     landing: pending
     closeout: pending

--- a/crates/gateway/docs/project_management/packs/active/chatgpt-codex-oauth-backend-api-responses/threaded-seams/seam-2-substrate-auth-handoff-and-account-id-provenance/slice-2-inject-account-id-and-bounded-fallback.md
+++ b/crates/gateway/docs/project_management/packs/active/chatgpt-codex-oauth-backend-api-responses/threaded-seams/seam-2-substrate-auth-handoff-and-account-id-provenance/slice-2-inject-account-id-and-bounded-fallback.md
@@ -1,0 +1,45 @@
+---
+slice_id: S2
+seam_id: SEAM-2
+slice_kind: implementation
+execution_horizon: active
+status: decomposed
+plan_version: v1
+basis:
+  currentness: current
+  basis_ref: seam.md#basis
+  stale_triggers:
+    - the route contract changes the minimal header contract, header casing expectations, or provider request-builder shape
+    - auth-context resolution changes in a way that alters account-id precedence
+gates:
+  pre_exec:
+    review: pending
+    contract: pending
+    revalidation: pending
+  post_exec:
+    landing: pending
+    closeout: pending
+threads:
+  - THR-15
+contracts_produced: []
+contracts_consumed:
+  - C-14
+  - C-15
+open_remediations: []
+---
+### S2 - Inject Account Id And Bounded Fallback
+
+- **User/system value**: the provider sends the right `ChatGPT-Account-ID` header without taking over auth ownership.
+- **Scope (in/out)**:
+  - In: inject `ChatGPT-Account-ID` from resolved auth context, keep JWT parsing as bounded fallback, and fail before upstream when identity cannot be resolved.
+  - Out: route contract shaping, seam-exit publication, and broad OAuth UX changes.
+- **Acceptance criteria**:
+  - provider request builder injects `ChatGPT-Account-ID` from resolved auth context first
+  - JWT-derived fallback remains bounded and explicit
+  - unresolved identity returns the normal failure envelope before the upstream call
+- **Dependencies**: `S00`, `S1`, `crates/gateway/src/providers/openai.rs`, `THR-15`
+- **Verification**:
+  - positive tests prove header injection from resolved auth context
+  - negative tests prove fallback does not redefine ownership
+- **Rollout/safety**: keep the provider path as a consumer of resolved auth context, not a host-credential owner.
+- **Review surface refs**: `../../review_surfaces.md` (`R3`) and `review.md`

--- a/crates/gateway/docs/project_management/packs/active/chatgpt-codex-oauth-backend-api-responses/threaded-seams/seam-2-substrate-auth-handoff-and-account-id-provenance/slice-3-verify-auth-source-and-failure-posture.md
+++ b/crates/gateway/docs/project_management/packs/active/chatgpt-codex-oauth-backend-api-responses/threaded-seams/seam-2-substrate-auth-handoff-and-account-id-provenance/slice-3-verify-auth-source-and-failure-posture.md
@@ -1,0 +1,45 @@
+---
+slice_id: S3
+seam_id: SEAM-2
+slice_kind: conformance
+execution_horizon: active
+status: decomposed
+plan_version: v1
+basis:
+  currentness: current
+  basis_ref: seam.md#basis
+  stale_triggers:
+    - the route contract or auth-handoff contract changes the accepted auth-source behavior
+    - the gateway's failure envelope or provider injection order changes
+gates:
+  pre_exec:
+    review: pending
+    contract: pending
+    revalidation: pending
+  post_exec:
+    landing: pending
+    closeout: pending
+threads:
+  - THR-15
+contracts_produced: []
+contracts_consumed:
+  - C-14
+  - C-15
+open_remediations: []
+---
+### S3 - Verify Auth Source And Failure Posture
+
+- **User/system value**: deterministic evidence proves the integrated auth owner line instead of leaving it as an implementation assumption.
+- **Scope (in/out)**:
+  - In: add verification surfaces for integrated versus standalone source selection, explicit precedence, and pre-upstream failure behavior.
+  - Out: route contract shaping, provider header wiring, and seam-exit publication accounting.
+- **Acceptance criteria**:
+  - deterministic checks prove integrated and standalone modes remain distinct
+  - unresolved identity fails before upstream
+  - docs and tests name the same owner line and fallback posture
+- **Dependencies**: `S00`, `S1`, `S2`, `crates/gateway/tests/`, `crates/gateway/docs/OAUTH_SETUP.md`, `crates/gateway/docs/OAUTH_TESTING.md`, `THR-15`
+- **Verification**:
+  - positive tests prove source precedence and bounded fallback
+  - negative tests prove unresolved identity fails deterministically
+- **Rollout/safety**: keep the conformance surface route-specific and explicit.
+- **Review surface refs**: `../../review_surfaces.md` (`R3`) and `review.md`

--- a/crates/gateway/docs/project_management/packs/active/chatgpt-codex-oauth-backend-api-responses/threaded-seams/seam-2-substrate-auth-handoff-and-account-id-provenance/slice-3-verify-auth-source-and-failure-posture.md
+++ b/crates/gateway/docs/project_management/packs/active/chatgpt-codex-oauth-backend-api-responses/threaded-seams/seam-2-substrate-auth-handoff-and-account-id-provenance/slice-3-verify-auth-source-and-failure-posture.md
@@ -3,7 +3,7 @@ slice_id: S3
 seam_id: SEAM-2
 slice_kind: conformance
 execution_horizon: active
-status: decomposed
+status: exec-ready
 plan_version: v1
 basis:
   currentness: current
@@ -13,9 +13,9 @@ basis:
     - the gateway's failure envelope or provider injection order changes
 gates:
   pre_exec:
-    review: pending
-    contract: pending
-    revalidation: pending
+    review: passed
+    contract: passed
+    revalidation: passed
   post_exec:
     landing: pending
     closeout: pending

--- a/crates/gateway/docs/project_management/packs/active/chatgpt-codex-oauth-backend-api-responses/threaded-seams/seam-2-substrate-auth-handoff-and-account-id-provenance/slice-99-seam-exit-gate.md
+++ b/crates/gateway/docs/project_management/packs/active/chatgpt-codex-oauth-backend-api-responses/threaded-seams/seam-2-substrate-auth-handoff-and-account-id-provenance/slice-99-seam-exit-gate.md
@@ -1,0 +1,44 @@
+---
+slice_id: S99
+seam_id: SEAM-2
+slice_kind: seam_exit_gate
+execution_horizon: active
+status: decomposed
+plan_version: v1
+basis:
+  currentness: current
+  basis_ref: seam.md#basis
+  stale_triggers:
+    - closeout reveals that owner-line precedence, fallback behavior, or provider injection landed differently than planned
+    - `THR-15` cannot be published because the canonical auth-handoff contract or verification evidence is incomplete
+gates:
+  pre_exec:
+    review: pending
+    contract: pending
+    revalidation: pending
+  post_exec:
+    landing: pending
+    closeout: pending
+threads:
+  - THR-15
+contracts_produced:
+  - C-15
+contracts_consumed:
+  - C-15
+open_remediations: []
+---
+### S99 - Seam Exit Gate
+
+- **User/system value**: downstream promotion consumes closeout-backed auth truth instead of guessing whether integrated ownership really landed.
+- **Scope (in/out)**:
+  - In: capture landed evidence, canonical contract publication, `THR-15` publication state, stale triggers, remediation disposition, and one promotion-readiness signal for downstream seams.
+  - Out: unfinished implementation work, route contract changes, and whole-pack conformance ownership.
+- **Acceptance criteria**:
+  - `../../governance/seam-2-closeout.md` records the landed evidence set, the `THR-15` publication decision, stale triggers, remediation disposition, and one promotion-readiness statement
+  - the closeout explicitly states whether integrated mode uses Substrate-delivered auth context first and whether fallback remained bounded
+- **Dependencies**: `S00`, `S1`, `S2`, `S3`, `THR-15`, `C-15`
+- **Verification**:
+  - the closeout artifact names the canonical contract note, landed implementation anchors, verification evidence, and the `THR-15` publication decision
+  - pass condition: downstream seams can consume `THR-15` without reverse-engineering provider code
+- **Rollout/safety**: do not hide unresolved auth ownership inside seam exit; if route truth is incomplete, keep promotion readiness blocked.
+- **Review surface refs**: `../../review_surfaces.md` (`R3`) and `review.md`

--- a/crates/gateway/docs/project_management/packs/active/chatgpt-codex-oauth-backend-api-responses/threaded-seams/seam-2-substrate-auth-handoff-and-account-id-provenance/slice-99-seam-exit-gate.md
+++ b/crates/gateway/docs/project_management/packs/active/chatgpt-codex-oauth-backend-api-responses/threaded-seams/seam-2-substrate-auth-handoff-and-account-id-provenance/slice-99-seam-exit-gate.md
@@ -3,7 +3,7 @@ slice_id: S99
 seam_id: SEAM-2
 slice_kind: seam_exit_gate
 execution_horizon: active
-status: decomposed
+status: exec-ready
 plan_version: v1
 basis:
   currentness: current
@@ -13,9 +13,9 @@ basis:
     - `THR-15` cannot be published because the canonical auth-handoff contract or verification evidence is incomplete
 gates:
   pre_exec:
-    review: pending
-    contract: pending
-    revalidation: pending
+    review: passed
+    contract: passed
+    revalidation: passed
   post_exec:
     landing: pending
     closeout: pending

--- a/crates/gateway/docs/project_management/packs/active/chatgpt-codex-oauth-backend-api-responses/threaded-seams/seam-3-codex-route-conformance-and-drift-guards/review.md
+++ b/crates/gateway/docs/project_management/packs/active/chatgpt-codex-oauth-backend-api-responses/threaded-seams/seam-3-codex-route-conformance-and-drift-guards/review.md
@@ -1,0 +1,61 @@
+---
+seam_id: SEAM-3
+review_phase: pre_exec
+execution_horizon: active
+basis_ref: seam.md#basis
+---
+# Review Bundle - SEAM-3 Codex Route Conformance And Drift Guards
+
+This artifact feeds `gates.pre_exec.review`.
+`../../review_surfaces.md` remains pack orientation only.
+
+## Falsification questions
+
+- Do the planned regressions still prove the real route contract, or are they drifting toward implementation-shaped assertions that miss caller-visible breakage?
+- Does the conformance plan keep integrated auth ownership and standalone fallback distinct, or would the suite accidentally bless standalone local behavior as integrated truth?
+- Does the suite still fail before caller-visible drift ships when the route matrix, semantic event assembly, or auth-failure envelope changes?
+
+## R1 - Deterministic route regression surface
+
+```mermaid
+flowchart LR
+  FIX["Fixture-backed requests"] --> ROUTE["Codex route handlers"]
+  ROUTE --> UP["Route-local provider contract"]
+  UP --> SSE["Semantic SSE expectations"]
+  SSE --> ASSERT["Deterministic sync + stream assertions"]
+```
+
+## R2 - Auth provenance verification surface
+
+```mermaid
+flowchart LR
+  INT["Integrated handoff truth"] --> TESTS["Auth-source regressions"]
+  STAND["Standalone bounded fallback"] --> TESTS
+  TESTS --> ENVELOPE["Shared auth error envelope"]
+  ENVELOPE --> CALLER["Caller-visible failure contract"]
+```
+
+## Likely mismatch hotspots
+
+- The route already has strong provider-local tests, but SEAM-3 must keep route-boundary and doc-level evidence aligned so maintenance does not rely on private code knowledge alone.
+- Auth provenance is now closeout-backed, so the conformance seam must assert that integrated truth and standalone fallback stay distinct instead of treating any successful header injection as sufficient proof.
+- Maintenance docs can easily drift toward generic OAuth guidance; the conformance seam must keep route-specific stale triggers and evidence anchors explicit.
+
+## Pre-exec findings
+
+- `THR-14` and `THR-15` are both published and revalidated against `../../governance/seam-1-closeout.md`, `../../governance/seam-2-closeout.md`, the canonical route and auth-handoff contract notes, and the current route/docs test surfaces.
+- The owned conformance contract baseline can now be made concrete in `S00` without waiting on further upstream truth.
+- No blocking pre-exec remediations remain open for this seam.
+
+## Pre-exec gate disposition
+
+- **Review gate**: `passed`
+- **Contract gate**: `passed`; the owned conformance contract target and execution checklist are concrete in `S00`
+- **Revalidation gate**: `passed`; the seam was refreshed against the landed route and auth closeouts plus the current deterministic regression anchors
+- **Open remediations**: none
+
+## Planned seam-exit gate focus
+
+- **What must be true before downstream publication is legal**: the conformance contract must be concrete, deterministic regressions must cover the route matrix and auth-source posture, and docs must identify the same stale triggers the tests protect
+- **Which outbound contracts/threads matter most**: `C-16`, `THR-16`
+- **Which review-surface deltas would force downstream revalidation**: route compatibility changes, auth-source rule changes, or maintenance evidence anchors moving

--- a/crates/gateway/docs/project_management/packs/active/chatgpt-codex-oauth-backend-api-responses/threaded-seams/seam-3-codex-route-conformance-and-drift-guards/seam.md
+++ b/crates/gateway/docs/project_management/packs/active/chatgpt-codex-oauth-backend-api-responses/threaded-seams/seam-3-codex-route-conformance-and-drift-guards/seam.md
@@ -1,0 +1,101 @@
+---
+seam_id: SEAM-3
+seam_slug: codex-route-conformance-and-drift-guards
+status: exec-ready
+execution_horizon: active
+plan_version: v1
+basis:
+  currentness: current
+  source_seam_brief: ../../seam-3-codex-route-conformance-and-drift-guards.md
+  source_scope_ref: ../../scope_brief.md
+  upstream_closeouts:
+    - ../../governance/seam-1-closeout.md
+    - ../../governance/seam-2-closeout.md
+  required_threads:
+    - THR-14
+    - THR-15
+  stale_triggers:
+    - route-level request compatibility or semantic event rules change after `C-14` publishes
+    - auth-handoff ownership, field IDs, or fallback rules change after `C-15` publishes
+    - public normalized-core behavior changes in a way that invalidates the route-local fixture expectations
+gates:
+  pre_exec:
+    review: passed
+    contract: passed
+    revalidation: passed
+  post_exec:
+    landing: pending
+    closeout: pending
+seam_exit_gate:
+  required: true
+  planned_location: S99
+  status: pending
+open_remediations: []
+---
+# SEAM-3 - Codex Route Conformance And Drift Guards
+
+## Seam Brief (Restated)
+
+- **Goal / value**: lock the ChatGPT Codex route into deterministic regression proof so future edits cannot silently change request shaping, auth provenance, sync/stream parity, or reasoning visibility on this route.
+- **Type**: `conformance`
+- **Scope**
+  - In:
+    - deterministic sync and streaming conformance for the route-local compatibility matrix
+    - regression coverage for accepted and rejected request controls, continuation synthesis/order, reasoning gating, and minimal header posture
+    - verification that integrated mode does not require gateway-local auth-file reads while standalone mode remains bounded fallback
+    - route-specific maintenance docs and evidence anchors for future revalidation
+  - Out:
+    - broad OpenAI compatibility redesign beyond this route
+    - live production monitoring or continuous external probe automation
+    - reopening route or auth contract ownership after `C-14` and `C-15` publish
+- **Touch surface**:
+  - `crates/gateway/tests/openai_responses_conformance.rs`
+  - `crates/gateway/tests/openai_shared_parity.rs`
+  - `crates/gateway/src/server/openai_conformance_test_support.rs`
+  - `crates/gateway/docs/openai-compatibility.md`
+  - `crates/gateway/docs/OAUTH_SETUP.md`
+  - `crates/gateway/docs/OAUTH_TESTING.md`
+  - `crates/gateway/docs/contracts/chatgpt-codex-conformance-and-drift-guard.md`
+- **Verification**:
+  - keep the drift-guard contract concrete enough to enumerate positive and negative route cases, fixture namespaces, auth-source proofs, and required documentation updates
+  - prove sync and streaming derive from the same semantic upstream event source and that caller-visible controls are not silently stripped or degraded
+  - prove integrated auth stays Substrate-owned while standalone remains bounded fallback
+- **Basis posture**:
+  - **Currentness**: `current` (revalidated against the landed route and auth closeouts plus the current route test/doc surfaces)
+  - **Upstream closeouts assumed**:
+    - `../../governance/seam-1-closeout.md`
+    - `../../governance/seam-2-closeout.md`
+  - **Required threads**:
+    - `THR-14`
+    - `THR-15`
+- **Threading constraints**
+  - **Upstream blockers**: none at pre-exec; `THR-14` and `THR-15` are published and revalidated
+  - **Downstream blocked seams**: none in this pack; this seam publishes `THR-16` for future maintenance work
+  - **Contracts produced**: `C-16`
+  - **Contracts consumed**: `C-14`, `C-15`
+
+## Review bundle
+
+- `review.md` is the authoritative artifact for `gates.pre_exec.review`
+
+## Seam-exit gate plan
+
+- **Planned location**: `S99`
+- **Why this seam needs an explicit exit gate**: future maintenance should consume closeout-backed conformance truth instead of reverse-engineering fixtures, docs, and parity rules from scattered tests
+- **Expected contracts to publish**: `C-16`
+- **Expected threads to publish / advance**: `THR-16`
+- **Likely downstream stale triggers**: route compatibility changes, auth-source rule changes, or drift-guard evidence anchors moving
+- **Expected closeout evidence**: the conformance contract baseline, deterministic regression anchors, auth-source proof, and route-specific maintenance guidance
+
+## Slice index
+
+- `S00` -> `slice-00-freeze-conformance-and-drift-guard-contract.md`
+- `S1` -> `slice-1-lock-route-matrix-and-fixture-coverage.md`
+- `S2` -> `slice-2-verify-auth-provenance-and-failure-envelope.md`
+- `S3` -> `slice-3-align-maintenance-docs-and-evidence-anchors.md`
+- `S99` -> `slice-99-seam-exit-gate.md`
+
+## Governance pointers
+
+- Pack remediation log: `../../governance/remediation-log.md`
+- Seam closeout: `../../governance/seam-3-closeout.md`

--- a/crates/gateway/docs/project_management/packs/active/chatgpt-codex-oauth-backend-api-responses/threaded-seams/seam-3-codex-route-conformance-and-drift-guards/seam.md
+++ b/crates/gateway/docs/project_management/packs/active/chatgpt-codex-oauth-backend-api-responses/threaded-seams/seam-3-codex-route-conformance-and-drift-guards/seam.md
@@ -1,8 +1,8 @@
 ---
 seam_id: SEAM-3
 seam_slug: codex-route-conformance-and-drift-guards
-status: exec-ready
-execution_horizon: active
+status: landed
+execution_horizon: future
 plan_version: v1
 basis:
   currentness: current
@@ -24,12 +24,12 @@ gates:
     contract: passed
     revalidation: passed
   post_exec:
-    landing: pending
-    closeout: pending
+    landing: passed
+    closeout: passed
 seam_exit_gate:
   required: true
   planned_location: S99
-  status: pending
+  status: passed
 open_remediations: []
 ---
 # SEAM-3 - Codex Route Conformance And Drift Guards

--- a/crates/gateway/docs/project_management/packs/active/chatgpt-codex-oauth-backend-api-responses/threaded-seams/seam-3-codex-route-conformance-and-drift-guards/slice-00-freeze-conformance-and-drift-guard-contract.md
+++ b/crates/gateway/docs/project_management/packs/active/chatgpt-codex-oauth-backend-api-responses/threaded-seams/seam-3-codex-route-conformance-and-drift-guards/slice-00-freeze-conformance-and-drift-guard-contract.md
@@ -1,0 +1,52 @@
+---
+slice_id: S00
+seam_id: SEAM-3
+slice_kind: contract_definition
+execution_horizon: active
+status: exec-ready
+plan_version: v1
+basis:
+  currentness: current
+  basis_ref: seam.md#basis
+  stale_triggers:
+    - route compatibility or semantic event rules change after the conformance contract baseline is frozen
+    - auth-handoff ownership or fallback rules change after the conformance checklist is frozen
+gates:
+  pre_exec:
+    review: passed
+    contract: passed
+    revalidation: passed
+  post_exec:
+    landing: pending
+    closeout: pending
+threads:
+  - THR-16
+contracts_produced:
+  - C-16
+contracts_consumed:
+  - C-14
+  - C-15
+open_remediations: []
+---
+### S00 - Freeze Conformance And Drift-Guard Contract
+
+- **User/system value**: execution starts from one explicit conformance contract instead of rediscovering route and auth proof obligations from test files alone.
+- **Scope (in/out)**:
+  - In: freeze the deterministic conformance contract target, fixture and regression ownership, auth-source proof obligations, and maintenance-doc stale triggers.
+  - Out: landing the final accepted contract artifact, changing route behavior, or publishing seam-exit evidence.
+- **Acceptance criteria**:
+  - the canonical conformance contract target is fixed at `crates/gateway/docs/contracts/chatgpt-codex-conformance-and-drift-guard.md`
+  - the contract baseline names positive and negative route cases, auth-source proofs, fixture namespaces, and maintenance-doc obligations concretely enough for implementation
+  - the verification checklist names the exact code, test, and doc anchors that later prove the route stays deterministic
+- **Dependencies**: `../../threading.md`, `../../scope_brief.md`, `../../seam-3-codex-route-conformance-and-drift-guards.md`, `../../governance/seam-1-closeout.md`, `../../governance/seam-2-closeout.md`
+- **Verification**:
+  - a reviewer can explain what the conformance seam must prove without reverse-engineering current implementation diffs
+  - pass condition: the owned contract baseline is concrete enough that `SEAM-3` can execute without ambiguity
+- **Rollout/safety**: keep the contract deterministic and route-specific; do not hide drift-guard truth inside generic OAuth or OpenAI docs.
+
+Checklist:
+- Implement: codify the route-local sync/stream matrix, fixture ownership, and no-silent-degradation rules in `crates/gateway/tests/openai_responses_conformance.rs`
+- Implement: prove auth-source and auth-failure posture in route-boundary regressions and shared error-envelope tests
+- Implement: align maintenance docs so stale triggers and evidence anchors stay visible outside source code
+- Validate: keep the conformance contract descriptive-only at `crates/gateway/docs/contracts/chatgpt-codex-conformance-and-drift-guard.md`
+- Publish when landed: record deterministic regression anchors and `THR-16` publication in `../../governance/seam-3-closeout.md`

--- a/crates/gateway/docs/project_management/packs/active/chatgpt-codex-oauth-backend-api-responses/threaded-seams/seam-3-codex-route-conformance-and-drift-guards/slice-1-lock-route-matrix-and-fixture-coverage.md
+++ b/crates/gateway/docs/project_management/packs/active/chatgpt-codex-oauth-backend-api-responses/threaded-seams/seam-3-codex-route-conformance-and-drift-guards/slice-1-lock-route-matrix-and-fixture-coverage.md
@@ -1,0 +1,41 @@
+---
+slice_id: S1
+seam_id: SEAM-3
+slice_kind: conformance
+execution_horizon: active
+status: exec-ready
+plan_version: v1
+basis:
+  currentness: current
+  basis_ref: seam.md#basis
+gates:
+  pre_exec:
+    review: passed
+    contract: passed
+    revalidation: passed
+  post_exec:
+    landing: pending
+    closeout: pending
+threads:
+  - THR-14
+  - THR-16
+contracts_produced: []
+contracts_consumed:
+  - C-14
+  - C-16
+open_remediations: []
+---
+### S1 - Lock Route Matrix And Fixture Coverage
+
+- **User/system value**: the route matrix and semantic SSE expectations become durable regressions instead of best-effort knowledge.
+- **Scope (in/out)**:
+  - In: deterministic sync and streaming coverage for accepted and rejected controls, fixture namespaces, and semantic stream assembly.
+  - Out: auth ownership implementation changes and seam-exit publication.
+- **Acceptance criteria**:
+  - route-local positive and negative cases are concrete in deterministic regressions
+  - sync and stream assertions consume the same semantic route truth
+  - unsupported controls still fail explicitly rather than degrading silently
+- **Dependencies**: `S00`, `crates/gateway/tests/openai_responses_conformance.rs`, `crates/gateway/src/server/openai_conformance_test_support.rs`
+- **Verification**:
+  - positive tests prove the supported route matrix and fixture-backed sync/stream parity
+  - negative tests prove rejected controls and drift-sensitive cases fail deterministically

--- a/crates/gateway/docs/project_management/packs/active/chatgpt-codex-oauth-backend-api-responses/threaded-seams/seam-3-codex-route-conformance-and-drift-guards/slice-2-verify-auth-provenance-and-failure-envelope.md
+++ b/crates/gateway/docs/project_management/packs/active/chatgpt-codex-oauth-backend-api-responses/threaded-seams/seam-3-codex-route-conformance-and-drift-guards/slice-2-verify-auth-provenance-and-failure-envelope.md
@@ -1,0 +1,41 @@
+---
+slice_id: S2
+seam_id: SEAM-3
+slice_kind: conformance
+execution_horizon: active
+status: exec-ready
+plan_version: v1
+basis:
+  currentness: current
+  basis_ref: seam.md#basis
+gates:
+  pre_exec:
+    review: passed
+    contract: passed
+    revalidation: passed
+  post_exec:
+    landing: pending
+    closeout: pending
+threads:
+  - THR-15
+  - THR-16
+contracts_produced: []
+contracts_consumed:
+  - C-15
+  - C-16
+open_remediations: []
+---
+### S2 - Verify Auth Provenance And Failure Envelope
+
+- **User/system value**: the auth owner line stays contract-backed instead of regressing into token-shape inference or leaked provider errors.
+- **Scope (in/out)**:
+  - In: route-boundary proof for integrated-vs-standalone auth behavior, bounded fallback, and shared auth error-envelope posture.
+  - Out: auth-resolution implementation work and seam-exit publication.
+- **Acceptance criteria**:
+  - integrated and standalone auth-source proofs remain distinct and deterministic
+  - unresolved identity still fails before upstream with the shared auth envelope
+  - provider auth failures stay redacted and classified as `auth`
+- **Dependencies**: `S00`, `crates/gateway/tests/openai_shared_parity.rs`, `crates/gateway/src/providers/openai.rs`, `C-15`
+- **Verification**:
+  - positive tests prove explicit account-id precedence and the integrated handoff posture
+  - negative tests prove unresolved identity and provider auth failures remain shared auth-envelope behavior

--- a/crates/gateway/docs/project_management/packs/active/chatgpt-codex-oauth-backend-api-responses/threaded-seams/seam-3-codex-route-conformance-and-drift-guards/slice-3-align-maintenance-docs-and-evidence-anchors.md
+++ b/crates/gateway/docs/project_management/packs/active/chatgpt-codex-oauth-backend-api-responses/threaded-seams/seam-3-codex-route-conformance-and-drift-guards/slice-3-align-maintenance-docs-and-evidence-anchors.md
@@ -1,0 +1,40 @@
+---
+slice_id: S3
+seam_id: SEAM-3
+slice_kind: documentation
+execution_horizon: active
+status: exec-ready
+plan_version: v1
+basis:
+  currentness: current
+  basis_ref: seam.md#basis
+gates:
+  pre_exec:
+    review: passed
+    contract: passed
+    revalidation: passed
+  post_exec:
+    landing: pending
+    closeout: pending
+threads:
+  - THR-16
+contracts_produced: []
+contracts_consumed:
+  - C-14
+  - C-15
+  - C-16
+open_remediations: []
+---
+### S3 - Align Maintenance Docs And Evidence Anchors
+
+- **User/system value**: future maintainers can revalidate drift-sensitive behavior without reopening ADR discovery or spelunking private code paths.
+- **Scope (in/out)**:
+  - In: route-specific maintenance docs, stale triggers, and evidence-anchor alignment for future revalidation.
+  - Out: route or auth implementation changes and seam-exit publication.
+- **Acceptance criteria**:
+  - route-specific docs name the same stale triggers and evidence anchors the regressions protect
+  - maintenance guidance stays aligned with the conformance contract terms
+  - docs do not treat local OAuth artifacts as integrated trust-boundary authority
+- **Dependencies**: `S00`, `crates/gateway/docs/openai-compatibility.md`, `crates/gateway/docs/OAUTH_SETUP.md`, `crates/gateway/docs/OAUTH_TESTING.md`
+- **Verification**:
+  - doc review proves maintenance guidance, stale triggers, and evidence anchors match the regression plan

--- a/crates/gateway/docs/project_management/packs/active/chatgpt-codex-oauth-backend-api-responses/threaded-seams/seam-3-codex-route-conformance-and-drift-guards/slice-99-seam-exit-gate.md
+++ b/crates/gateway/docs/project_management/packs/active/chatgpt-codex-oauth-backend-api-responses/threaded-seams/seam-3-codex-route-conformance-and-drift-guards/slice-99-seam-exit-gate.md
@@ -1,0 +1,42 @@
+---
+slice_id: S99
+seam_id: SEAM-3
+slice_kind: seam_exit_gate
+execution_horizon: active
+status: exec-ready
+plan_version: v1
+basis:
+  currentness: current
+  basis_ref: seam.md#basis
+  stale_triggers:
+    - closeout reveals route matrix, auth-source proof, or maintenance evidence landed differently than planned
+    - `THR-16` cannot be published because the conformance contract or deterministic evidence set is incomplete
+gates:
+  pre_exec:
+    review: passed
+    contract: passed
+    revalidation: passed
+  post_exec:
+    landing: pending
+    closeout: pending
+threads:
+  - THR-16
+contracts_produced:
+  - C-16
+contracts_consumed:
+  - C-16
+open_remediations: []
+---
+### S99 - Seam Exit Gate
+
+- **User/system value**: future maintenance consumes closeout-backed drift-guard truth instead of inferring route and auth expectations from scattered tests.
+- **Scope (in/out)**:
+  - In: capture landed conformance evidence, the `THR-16` publication decision, stale triggers, remediation disposition, and one promotion-readiness signal for downstream maintenance.
+  - Out: unfinished implementation work, route or auth contract rewrites, and whole-pack governance beyond this seam.
+- **Acceptance criteria**:
+  - `../../governance/seam-3-closeout.md` records the landed evidence set, `THR-16` publication decision, stale triggers, remediation disposition, and one promotion-readiness statement
+  - the closeout explicitly states whether the conformance suite now protects route matrix, auth provenance, and no-silent-degradation posture
+- **Dependencies**: `S00`, `S1`, `S2`, `S3`, `THR-16`, `C-16`
+- **Verification**:
+  - the closeout artifact names the canonical contract target, landed regression anchors, maintenance-doc evidence, and the `THR-16` publication decision
+  - pass condition: future maintenance can consume `THR-16` without re-reading ADR discovery material

--- a/crates/gateway/docs/project_management/packs/active/chatgpt-codex-oauth-backend-api-responses/threading.md
+++ b/crates/gateway/docs/project_management/packs/active/chatgpt-codex-oauth-backend-api-responses/threading.md
@@ -48,10 +48,10 @@
   - **Consumer seam(s)**: `SEAM-2`, `SEAM-3`
   - **Carried contract IDs**: `C-14`
   - **Purpose**: publish the route contract and stream-native transport truth so auth ownership and conformance work can build on named, reviewable route behavior instead of ADR prose alone
-  - **State**: `published`
+  - **State**: `revalidated`
   - **Revalidation trigger**: the upstream endpoint path, minimal header contract, accepted-field subset, continuation legality rules, or authoritative semantic event family changes
   - **Satisfied by**: the canonical route contract note plus deterministic provider-focused verification that proves sync and streaming share the same upstream event source and compatibility overlay
-  - **Notes**: this thread must preserve thin public ingress by keeping route-specific logic below the normalized-core boundary
+  - **Notes**: this thread was published by the `SEAM-1` closeout record and has now been revalidated by `SEAM-2` pre-exec review against the landed route contract, the seam-1 seam-exit record, and the current provider/auth evidence anchors; later consumers still rerun promotion-time revalidation if a stale trigger fires
 
 - **Thread ID**: `THR-15`
   - **Producer seam**: `SEAM-2`

--- a/crates/gateway/docs/project_management/packs/active/chatgpt-codex-oauth-backend-api-responses/threading.md
+++ b/crates/gateway/docs/project_management/packs/active/chatgpt-codex-oauth-backend-api-responses/threading.md
@@ -8,7 +8,7 @@
   - only `SEAM-1` is eligible for authoritative downstream decomposition by default
   - `SEAM-2` may later receive seam-local review and slices, but only after `THR-14` is published
   - `SEAM-3` remains seam-brief depth only until both `THR-14` and `THR-15` are published
-  - canonical contract refs for this pack are reserved under `docs/contracts/`
+  - canonical contract refs for this pack are reserved under `crates/gateway/docs/contracts/`
 
 ## Contract registry
 
@@ -19,7 +19,7 @@
   - **Derived consumers**: future Codex-route maintenance and any later provider-side work that must preserve public ingress semantics while changing the routed upstream transport
   - **Thread IDs**: `THR-14`
   - **Definition**: the dedicated ChatGPT Codex OAuth route contract for `https://chatgpt.com/backend-api/codex/responses`, including endpoint parity for sync and streaming, the `pass | translate | force | reject` compatibility overlay, typed `message` item emission, flat function tool/tool-choice shapes, semantic stream assembly, sync-drain failure behavior, and the non-public reasoning visibility rule
-  - **Canonical contract ref**: `docs/contracts/chatgpt-codex-route-contract.md`
+  - **Canonical contract ref**: `crates/gateway/docs/contracts/chatgpt-codex-route-contract.md`
   - **Versioning / compat**: route compatibility widens only through explicit route-specific revalidation; unsupported caller-visible controls must fail explicitly rather than being silently stripped or degraded
 
 - **Contract ID**: `C-15`
@@ -29,7 +29,7 @@
   - **Derived consumers**: future Substrate integration and standalone-compat maintenance work
   - **Thread IDs**: `THR-15`
   - **Definition**: the ChatGPT Codex auth-handoff contract for integrated and standalone mode, including authoritative account-id ownership, auth field identifiers, delivery posture, explicit `account_id` precedence over JWT fallback, and pre-upstream failure behavior when no valid account identity exists
-  - **Canonical contract ref**: `docs/contracts/chatgpt-codex-auth-handoff-contract.md`
+  - **Canonical contract ref**: `crates/gateway/docs/contracts/chatgpt-codex-auth-handoff-contract.md`
   - **Versioning / compat**: integrated mode keeps Substrate as the owner of host credential reads and secret delivery; standalone mode remains a bounded fallback and must not redefine that owner line
 
 - **Contract ID**: `C-16`
@@ -39,7 +39,7 @@
   - **Derived consumers**: future Codex-route changes that need drift-guard evidence before they land
   - **Thread IDs**: `THR-16`
   - **Definition**: deterministic conformance and drift-guard suite for the ChatGPT Codex route, covering accepted vs rejected request controls, sync/stream parity, continuation synthesis/order rules, reasoning gating, auth-source rules, and the route's no-silent-degradation posture
-  - **Canonical contract ref**: `docs/contracts/chatgpt-codex-conformance-and-drift-guard.md`
+  - **Canonical contract ref**: `crates/gateway/docs/contracts/chatgpt-codex-conformance-and-drift-guard.md`
   - **Versioning / compat**: the suite should stay offline and deterministic where possible, using captured probe evidence and fixture-backed expectations instead of live upstream network dependence in the core regression path
 
 ## Thread registry

--- a/crates/gateway/docs/project_management/packs/active/chatgpt-codex-oauth-backend-api-responses/threading.md
+++ b/crates/gateway/docs/project_management/packs/active/chatgpt-codex-oauth-backend-api-responses/threading.md
@@ -1,0 +1,101 @@
+# Threading - ChatGPT Codex OAuth Backend-API Responses
+
+## Execution horizon summary
+
+- **Active seam**: `SEAM-1`
+- **Next seam**: `SEAM-2`
+- **Policy**:
+  - only `SEAM-1` is eligible for authoritative downstream decomposition by default
+  - `SEAM-2` may later receive seam-local review and slices, but only after `THR-14` is published
+  - `SEAM-3` remains seam-brief depth only until both `THR-14` and `THR-15` are published
+  - canonical contract refs for this pack are reserved under `docs/contracts/`
+
+## Contract registry
+
+- **Contract ID**: `C-14`
+  - **Type**: `API`
+  - **Owner seam**: `SEAM-1`
+  - **Direct consumers**: `SEAM-2`, `SEAM-3`
+  - **Derived consumers**: future Codex-route maintenance and any later provider-side work that must preserve public ingress semantics while changing the routed upstream transport
+  - **Thread IDs**: `THR-14`
+  - **Definition**: the dedicated ChatGPT Codex OAuth route contract for `https://chatgpt.com/backend-api/codex/responses`, including endpoint parity for sync and streaming, the `pass | translate | force | reject` compatibility overlay, typed `message` item emission, flat function tool/tool-choice shapes, semantic stream assembly, sync-drain failure behavior, and the non-public reasoning visibility rule
+  - **Canonical contract ref**: `docs/contracts/chatgpt-codex-route-contract.md`
+  - **Versioning / compat**: route compatibility widens only through explicit route-specific revalidation; unsupported caller-visible controls must fail explicitly rather than being silently stripped or degraded
+
+- **Contract ID**: `C-15`
+  - **Type**: `state`
+  - **Owner seam**: `SEAM-2`
+  - **Direct consumers**: `SEAM-3`
+  - **Derived consumers**: future Substrate integration and standalone-compat maintenance work
+  - **Thread IDs**: `THR-15`
+  - **Definition**: the ChatGPT Codex auth-handoff contract for integrated and standalone mode, including authoritative account-id ownership, auth field identifiers, delivery posture, explicit `account_id` precedence over JWT fallback, and pre-upstream failure behavior when no valid account identity exists
+  - **Canonical contract ref**: `docs/contracts/chatgpt-codex-auth-handoff-contract.md`
+  - **Versioning / compat**: integrated mode keeps Substrate as the owner of host credential reads and secret delivery; standalone mode remains a bounded fallback and must not redefine that owner line
+
+- **Contract ID**: `C-16`
+  - **Type**: `UX affordance`
+  - **Owner seam**: `SEAM-3`
+  - **Direct consumers**: gateway maintainers and operators
+  - **Derived consumers**: future Codex-route changes that need drift-guard evidence before they land
+  - **Thread IDs**: `THR-16`
+  - **Definition**: deterministic conformance and drift-guard suite for the ChatGPT Codex route, covering accepted vs rejected request controls, sync/stream parity, continuation synthesis/order rules, reasoning gating, auth-source rules, and the route's no-silent-degradation posture
+  - **Canonical contract ref**: `docs/contracts/chatgpt-codex-conformance-and-drift-guard.md`
+  - **Versioning / compat**: the suite should stay offline and deterministic where possible, using captured probe evidence and fixture-backed expectations instead of live upstream network dependence in the core regression path
+
+## Thread registry
+
+- **Thread ID**: `THR-14`
+  - **Producer seam**: `SEAM-1`
+  - **Consumer seam(s)**: `SEAM-2`, `SEAM-3`
+  - **Carried contract IDs**: `C-14`
+  - **Purpose**: publish the route contract and stream-native transport truth so auth ownership and conformance work can build on named, reviewable route behavior instead of ADR prose alone
+  - **State**: `defined`
+  - **Revalidation trigger**: the upstream endpoint path, minimal header contract, accepted-field subset, continuation legality rules, or authoritative semantic event family changes
+  - **Satisfied by**: the canonical route contract note plus deterministic provider-focused verification that proves sync and streaming share the same upstream event source and compatibility overlay
+  - **Notes**: this thread must preserve thin public ingress by keeping route-specific logic below the normalized-core boundary
+
+- **Thread ID**: `THR-15`
+  - **Producer seam**: `SEAM-2`
+  - **Consumer seam(s)**: `SEAM-3`
+  - **Carried contract IDs**: `C-15`
+  - **Purpose**: publish the integrated-versus-standalone auth owner line so conformance work can prove account-id sourcing, failure posture, and header injection without rediscovering trust-boundary assumptions
+  - **State**: `defined`
+  - **Revalidation trigger**: Substrate auth-bundle delivery semantics, the closed `cli:codex` field set, standalone compatibility inputs, or provider auth-context resolution rules change materially
+  - **Satisfied by**: the canonical auth-handoff contract plus verification surfaces that prove integrated mode does not require host-local auth-file reads while standalone mode remains bounded
+  - **Notes**: the current gateway token store does not carry explicit `account_id`, so this thread must make the standalone compatibility story explicit instead of letting provider code infer ownership ad hoc
+
+- **Thread ID**: `THR-16`
+  - **Producer seam**: `SEAM-3`
+  - **Consumer seam(s)**: future maintenance work outside this pack
+  - **Carried contract IDs**: `C-16`
+  - **Purpose**: publish the drift-guard baseline so future route changes cannot silently regress request shaping, semantic event assembly, or auth provenance
+  - **State**: `identified`
+  - **Revalidation trigger**: new route-specific controls are added, upstream behavior drifts, or auth/normalized-core changes require fixture updates
+  - **Satisfied by**: deterministic fixtures, route-local regression tests, and documentation that explicitly names what the Codex route preserves, forces, translates, and rejects
+  - **Notes**: this thread should remain the maintenance and revalidation surface for future Codex-route work rather than turning every drift fix into a fresh discovery cycle
+
+## Dependency graph
+
+```mermaid
+flowchart LR
+  S1["SEAM-1
+  Route contract + stream-native transport"] -->|"THR-14 / C-14"| S2["SEAM-2
+  Auth handoff + account-id provenance"]
+  S1 -->|"THR-14 / C-14"| S3["SEAM-3
+  Conformance + drift guards"]
+  S2 -->|"THR-15 / C-15"| S3
+  S3 -->|"THR-16 / C-16"| FUT["Future Codex-route
+  maintenance"]
+```
+
+## Critical path
+
+1. Freeze `C-14` so the gateway has one explicit ChatGPT Codex route contract for endpoint parity, compatibility overlay, typed message items, semantic stream assembly, and sync-drain failure behavior.
+2. Freeze `C-15` so integrated mode consumes Substrate-delivered auth context with explicit account-id precedence and standalone mode is reduced to a bounded fallback.
+3. Publish `C-16` so future route changes are forced through deterministic drift guards instead of silent behavior changes.
+
+## Workstreams
+
+- **WS-A Route contract and provider boundary**: `SEAM-1` owns the provider-side request/response contract, event assembly, and route-local compatibility matrix
+- **WS-B Auth ownership and handoff**: `SEAM-2` owns integrated-versus-standalone account-id provenance, auth bundle semantics, and provider header injection ownership
+- **WS-C Conformance and documentation**: `SEAM-3` owns deterministic regressions, fixture/evidence posture, and route-specific maintenance guidance

--- a/crates/gateway/docs/project_management/packs/active/chatgpt-codex-oauth-backend-api-responses/threading.md
+++ b/crates/gateway/docs/project_management/packs/active/chatgpt-codex-oauth-backend-api-responses/threading.md
@@ -2,11 +2,11 @@
 
 ## Execution horizon summary
 
-- **Active seam**: `SEAM-3`
-- **Next seam**: none yet
+- **Active seam**: none
+- **Next seam**: none
 - **Policy**:
-  - `SEAM-3` is now eligible for authoritative downstream decomposition because both `THR-14` and `THR-15` are published and closeout-backed
-  - only `SEAM-3` is eligible for authoritative downstream decomposition by default
+  - no seam is currently eligible for authoritative downstream decomposition because the forward planning window is empty
+  - future Codex-route maintenance should consume `THR-16` as the published drift-guard baseline instead of reopening `SEAM-3`
   - canonical contract refs for this pack are reserved under `crates/gateway/docs/contracts/`
 
 ## Contract registry
@@ -68,10 +68,10 @@
   - **Consumer seam(s)**: future maintenance work outside this pack
   - **Carried contract IDs**: `C-16`
   - **Purpose**: publish the drift-guard baseline so future route changes cannot silently regress request shaping, semantic event assembly, or auth provenance
-  - **State**: `identified`
+  - **State**: `published`
   - **Revalidation trigger**: new route-specific controls are added, upstream behavior drifts, or auth/normalized-core changes require fixture updates
   - **Satisfied by**: deterministic fixtures, route-local regression tests, and documentation that explicitly names what the Codex route preserves, forces, translates, and rejects
-  - **Notes**: this thread should remain the maintenance and revalidation surface for future Codex-route work rather than turning every drift fix into a fresh discovery cycle
+  - **Notes**: this thread was published by the `SEAM-3` closeout record and should remain the maintenance and revalidation surface for future Codex-route work rather than turning every drift fix into a fresh discovery cycle
 
 ## Dependency graph
 

--- a/crates/gateway/docs/project_management/packs/active/chatgpt-codex-oauth-backend-api-responses/threading.md
+++ b/crates/gateway/docs/project_management/packs/active/chatgpt-codex-oauth-backend-api-responses/threading.md
@@ -49,7 +49,7 @@
   - **Consumer seam(s)**: `SEAM-2`, `SEAM-3`
   - **Carried contract IDs**: `C-14`
   - **Purpose**: publish the route contract and stream-native transport truth so auth ownership and conformance work can build on named, reviewable route behavior instead of ADR prose alone
-  - **State**: `defined`
+  - **State**: `published`
   - **Revalidation trigger**: the upstream endpoint path, minimal header contract, accepted-field subset, continuation legality rules, or authoritative semantic event family changes
   - **Satisfied by**: the canonical route contract note plus deterministic provider-focused verification that proves sync and streaming share the same upstream event source and compatibility overlay
   - **Notes**: this thread must preserve thin public ingress by keeping route-specific logic below the normalized-core boundary

--- a/crates/gateway/docs/project_management/packs/active/chatgpt-codex-oauth-backend-api-responses/threading.md
+++ b/crates/gateway/docs/project_management/packs/active/chatgpt-codex-oauth-backend-api-responses/threading.md
@@ -2,11 +2,11 @@
 
 ## Execution horizon summary
 
-- **Active seam**: `SEAM-2`
+- **Active seam**: `SEAM-3`
 - **Next seam**: none yet
 - **Policy**:
-  - `SEAM-3` remains seam-brief depth only until both `THR-14` and `THR-15` are published
-  - only `SEAM-2` is eligible for authoritative downstream decomposition by default
+  - `SEAM-3` is now eligible for authoritative downstream decomposition because both `THR-14` and `THR-15` are published and closeout-backed
+  - only `SEAM-3` is eligible for authoritative downstream decomposition by default
   - canonical contract refs for this pack are reserved under `crates/gateway/docs/contracts/`
 
 ## Contract registry
@@ -58,10 +58,10 @@
   - **Consumer seam(s)**: `SEAM-3`
   - **Carried contract IDs**: `C-15`
   - **Purpose**: publish the integrated-versus-standalone auth owner line so conformance work can prove account-id sourcing, failure posture, and header injection without rediscovering trust-boundary assumptions
-  - **State**: `defined`
+  - **State**: `revalidated`
   - **Revalidation trigger**: Substrate auth-bundle delivery semantics, the closed `cli:codex` field set, standalone compatibility inputs, or provider auth-context resolution rules change materially
   - **Satisfied by**: the canonical auth-handoff contract plus verification surfaces that prove integrated mode does not require host-local auth-file reads while standalone mode remains bounded
-  - **Notes**: the current gateway token store does not carry explicit `account_id`, so this thread must make the standalone compatibility story explicit instead of letting provider code infer ownership ad hoc
+  - **Notes**: this thread was published by the `SEAM-2` closeout record and is now revalidated for `SEAM-3` against the landed auth-handoff contract, auth-context resolution, provider injection proof, and OAuth doc alignment
 
 - **Thread ID**: `THR-16`
   - **Producer seam**: `SEAM-3`

--- a/crates/gateway/docs/project_management/packs/active/chatgpt-codex-oauth-backend-api-responses/threading.md
+++ b/crates/gateway/docs/project_management/packs/active/chatgpt-codex-oauth-backend-api-responses/threading.md
@@ -2,12 +2,11 @@
 
 ## Execution horizon summary
 
-- **Active seam**: `SEAM-1`
-- **Next seam**: `SEAM-2`
+- **Active seam**: `SEAM-2`
+- **Next seam**: none yet
 - **Policy**:
-  - only `SEAM-1` is eligible for authoritative downstream decomposition by default
-  - `SEAM-2` may later receive seam-local review and slices, but only after `THR-14` is published
   - `SEAM-3` remains seam-brief depth only until both `THR-14` and `THR-15` are published
+  - only `SEAM-2` is eligible for authoritative downstream decomposition by default
   - canonical contract refs for this pack are reserved under `crates/gateway/docs/contracts/`
 
 ## Contract registry

--- a/crates/gateway/src/auth/codex_auth_context.rs
+++ b/crates/gateway/src/auth/codex_auth_context.rs
@@ -1,0 +1,347 @@
+#![allow(dead_code)]
+
+use anyhow::{anyhow, Context, Result};
+use base64::{engine::general_purpose::URL_SAFE_NO_PAD, Engine as _};
+use secrecy::{ExposeSecret, SecretString};
+use std::{env, path::Path};
+
+use super::codex_auth_state::CodexAuthState;
+
+pub const SUBSTRATE_LLM_BACKEND_AUTH_CLI_CODEX_ACCOUNT_ID: &str =
+    "SUBSTRATE_LLM_BACKEND_AUTH_CLI_CODEX_ACCOUNT_ID";
+pub const SUBSTRATE_LLM_BACKEND_AUTH_CLI_CODEX_ACCESS_TOKEN: &str =
+    "SUBSTRATE_LLM_BACKEND_AUTH_CLI_CODEX_ACCESS_TOKEN";
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum CodexAuthMode {
+    Integrated,
+    Standalone,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum CodexAccountIdSource {
+    Explicit,
+    JwtFallback,
+}
+
+#[derive(Debug, Clone)]
+pub struct ResolvedCodexAuthContext {
+    pub mode: CodexAuthMode,
+    pub account_id: String,
+    pub account_id_source: CodexAccountIdSource,
+    pub access_token: SecretString,
+}
+
+#[derive(Debug, Clone)]
+pub struct CodexIntegratedAuthHandoff {
+    pub account_id: Option<String>,
+    pub access_token: SecretString,
+}
+
+impl CodexIntegratedAuthHandoff {
+    pub fn new(account_id: Option<String>, access_token: SecretString) -> Self {
+        Self {
+            account_id,
+            access_token,
+        }
+    }
+
+    pub fn from_env() -> Result<Option<Self>> {
+        let access_token = read_env_trimmed(SUBSTRATE_LLM_BACKEND_AUTH_CLI_CODEX_ACCESS_TOKEN)?;
+        let Some(access_token) = access_token else {
+            let account_id = read_env_trimmed(SUBSTRATE_LLM_BACKEND_AUTH_CLI_CODEX_ACCOUNT_ID)?;
+            if account_id.is_some() {
+                return Err(anyhow!(
+                    "integrated Codex auth handoff is incomplete: {} is set without {}",
+                    SUBSTRATE_LLM_BACKEND_AUTH_CLI_CODEX_ACCOUNT_ID,
+                    SUBSTRATE_LLM_BACKEND_AUTH_CLI_CODEX_ACCESS_TOKEN
+                ));
+            }
+
+            return Ok(None);
+        };
+
+        let account_id = read_env_trimmed(SUBSTRATE_LLM_BACKEND_AUTH_CLI_CODEX_ACCOUNT_ID)?;
+        Ok(Some(Self::new(account_id, SecretString::new(access_token))))
+    }
+}
+
+#[derive(Debug, Clone)]
+pub enum CodexAuthSelection {
+    Integrated(CodexIntegratedAuthHandoff),
+    Standalone(CodexAuthState),
+}
+
+impl CodexAuthSelection {
+    pub fn from_env_or_local_auth_state(local_auth_path: impl AsRef<Path>) -> Result<Self> {
+        if let Some(handoff) = CodexIntegratedAuthHandoff::from_env()? {
+            Ok(Self::Integrated(handoff))
+        } else {
+            Ok(Self::Standalone(CodexAuthState::load(local_auth_path)?))
+        }
+    }
+
+    pub fn mode(&self) -> CodexAuthMode {
+        match self {
+            Self::Integrated(_) => CodexAuthMode::Integrated,
+            Self::Standalone(_) => CodexAuthMode::Standalone,
+        }
+    }
+
+    pub fn resolve(self) -> Result<ResolvedCodexAuthContext> {
+        match self {
+            Self::Integrated(handoff) => resolve_selected_mode(
+                CodexAuthMode::Integrated,
+                handoff.account_id,
+                handoff.access_token,
+            ),
+            Self::Standalone(state) => resolve_selected_mode(
+                CodexAuthMode::Standalone,
+                state.account_id,
+                state.access_token,
+            ),
+        }
+    }
+}
+
+fn resolve_selected_mode(
+    mode: CodexAuthMode,
+    explicit_account_id: Option<String>,
+    access_token: SecretString,
+) -> Result<ResolvedCodexAuthContext> {
+    if let Some(account_id) = explicit_account_id
+        .as_deref()
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+    {
+        return Ok(ResolvedCodexAuthContext {
+            mode,
+            account_id: account_id.to_string(),
+            account_id_source: CodexAccountIdSource::Explicit,
+            access_token,
+        });
+    }
+
+    let jwt_account_id = extract_account_id(access_token.expose_secret())
+        .context("Codex auth context could not resolve account_id from JWT fallback")?;
+
+    Ok(ResolvedCodexAuthContext {
+        mode,
+        account_id: jwt_account_id,
+        account_id_source: CodexAccountIdSource::JwtFallback,
+        access_token,
+    })
+}
+
+fn extract_account_id(access_token: &str) -> Option<String> {
+    let parts: Vec<&str> = access_token.split('.').collect();
+    if parts.len() != 3 {
+        return None;
+    }
+
+    let decoded = URL_SAFE_NO_PAD.decode(parts[1]).ok()?;
+    let json_str = String::from_utf8(decoded).ok()?;
+    let json: serde_json::Value = serde_json::from_str(&json_str).ok()?;
+
+    json.get("https://api.openai.com/auth")?
+        .get("chatgpt_account_id")?
+        .as_str()
+        .map(|s| s.to_string())
+}
+
+fn read_env_trimmed(key: &str) -> Result<Option<String>> {
+    match env::var(key) {
+        Ok(value) => {
+            let value = value.trim().to_string();
+            if value.is_empty() {
+                Ok(None)
+            } else {
+                Ok(Some(value))
+            }
+        }
+        Err(env::VarError::NotPresent) => Ok(None),
+        Err(err) => Err(err).with_context(|| format!("Failed to read {}", key)),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use base64::engine::general_purpose::URL_SAFE_NO_PAD;
+    use secrecy::ExposeSecret;
+    use std::fs;
+    use std::sync::Mutex;
+    use tempfile::TempDir;
+
+    static ENV_LOCK: once_cell::sync::Lazy<Mutex<()>> =
+        once_cell::sync::Lazy::new(|| Mutex::new(()));
+
+    fn codex_access_token(account_id: &str) -> SecretString {
+        let payload = serde_json::json!({
+            "https://api.openai.com/auth": {
+                "chatgpt_account_id": account_id
+            }
+        });
+        let encoded_payload = URL_SAFE_NO_PAD.encode(payload.to_string());
+        SecretString::new(format!("header.{}.signature", encoded_payload))
+    }
+
+    #[test]
+    fn integrated_mode_uses_substrate_account_id_first() {
+        let selection = CodexAuthSelection::Integrated(CodexIntegratedAuthHandoff::new(
+            Some("acct_explicit".to_string()),
+            codex_access_token("acct_jwt"),
+        ));
+
+        let resolved = selection.resolve().unwrap();
+
+        assert_eq!(resolved.mode, CodexAuthMode::Integrated);
+        assert_eq!(resolved.account_id, "acct_explicit");
+        assert_eq!(resolved.account_id_source, CodexAccountIdSource::Explicit);
+        assert_eq!(
+            resolved.access_token.expose_secret(),
+            codex_access_token("acct_jwt").expose_secret()
+        );
+    }
+
+    #[test]
+    fn integrated_mode_uses_jwt_fallback_when_explicit_account_id_is_absent() {
+        let selection = CodexAuthSelection::Integrated(CodexIntegratedAuthHandoff::new(
+            None,
+            codex_access_token("acct_jwt"),
+        ));
+
+        let resolved = selection.resolve().unwrap();
+
+        assert_eq!(resolved.mode, CodexAuthMode::Integrated);
+        assert_eq!(resolved.account_id, "acct_jwt");
+        assert_eq!(
+            resolved.account_id_source,
+            CodexAccountIdSource::JwtFallback
+        );
+    }
+
+    #[test]
+    fn standalone_mode_uses_explicit_account_id_first() {
+        let selection = CodexAuthSelection::Standalone(CodexAuthState::new(
+            Some("acct_local_explicit".to_string()),
+            codex_access_token("acct_local_jwt"),
+        ));
+
+        let resolved = selection.resolve().unwrap();
+
+        assert_eq!(resolved.mode, CodexAuthMode::Standalone);
+        assert_eq!(resolved.account_id, "acct_local_explicit");
+        assert_eq!(resolved.account_id_source, CodexAccountIdSource::Explicit);
+    }
+
+    #[test]
+    fn standalone_mode_uses_jwt_fallback_when_explicit_account_id_is_absent() {
+        let selection = CodexAuthSelection::Standalone(CodexAuthState::new(
+            None,
+            codex_access_token("acct_local_jwt"),
+        ));
+
+        let resolved = selection.resolve().unwrap();
+
+        assert_eq!(resolved.mode, CodexAuthMode::Standalone);
+        assert_eq!(resolved.account_id, "acct_local_jwt");
+        assert_eq!(
+            resolved.account_id_source,
+            CodexAccountIdSource::JwtFallback
+        );
+    }
+
+    #[test]
+    fn auth_context_resolution_fails_when_account_id_is_unresolvable() {
+        let selection = CodexAuthSelection::Standalone(CodexAuthState::new(
+            None,
+            SecretString::new("not-a-jwt".to_string()),
+        ));
+
+        let err = selection.resolve().unwrap_err();
+        assert!(err
+            .to_string()
+            .contains("could not resolve account_id from JWT fallback"));
+    }
+
+    #[test]
+    fn integrated_mode_from_env_uses_canonical_field_names() {
+        let _env_lock_guard = ENV_LOCK.lock().unwrap();
+
+        let temp_dir = TempDir::new().unwrap();
+        let _account_id_guard = EnvGuard::set(
+            SUBSTRATE_LLM_BACKEND_AUTH_CLI_CODEX_ACCOUNT_ID,
+            "acct_env_explicit",
+        );
+        let _access_token_guard = EnvGuard::set(
+            SUBSTRATE_LLM_BACKEND_AUTH_CLI_CODEX_ACCESS_TOKEN,
+            "header.eyJodHRwczovL2FwaS5vcGVuYWkuY29tL2F1dGgiOnsiY2hhdGdwdF9hY2NvdW50X2lkIjoiYWNjdF9lbnZfand0In19.signature",
+        );
+
+        let selection = CodexAuthSelection::from_env_or_local_auth_state(temp_dir.path()).unwrap();
+        match selection {
+            CodexAuthSelection::Integrated(handoff) => {
+                assert_eq!(handoff.account_id.as_deref(), Some("acct_env_explicit"));
+            }
+            _ => panic!("expected integrated selection"),
+        }
+    }
+
+    struct EnvGuard {
+        key: &'static str,
+        previous: Option<String>,
+    }
+
+    impl EnvGuard {
+        fn set(key: &'static str, value: &str) -> Self {
+            let previous = env::var(key).ok();
+            env::set_var(key, value);
+            Self { key, previous }
+        }
+
+        fn clear(key: &'static str) -> Self {
+            let previous = env::var(key).ok();
+            env::remove_var(key);
+            Self { key, previous }
+        }
+    }
+
+    impl Drop for EnvGuard {
+        fn drop(&mut self) {
+            if let Some(previous) = self.previous.take() {
+                env::set_var(self.key, previous);
+            } else {
+                env::remove_var(self.key);
+            }
+        }
+    }
+
+    #[test]
+    fn env_selection_falls_back_to_standalone_when_integrated_handoff_is_absent() {
+        let _env_lock_guard = ENV_LOCK.lock().unwrap();
+
+        let _account_id_guard = EnvGuard::clear(SUBSTRATE_LLM_BACKEND_AUTH_CLI_CODEX_ACCOUNT_ID);
+        let _access_token_guard =
+            EnvGuard::clear(SUBSTRATE_LLM_BACKEND_AUTH_CLI_CODEX_ACCESS_TOKEN);
+
+        let temp_dir = TempDir::new().unwrap();
+        let path = temp_dir.path().join("auth.json");
+        fs::write(
+            &path,
+            r#"{
+                "account_id": "acct_local",
+                "access_token": "header.eyJodHRwczovL2FwaS5vcGVuYWkuY29tL2F1dGgiOnsiY2hhdGdwdF9hY2NvdW50X2lkIjoiYWNjdF9sb2NhbF9qd3QifX0.signature"
+            }"#,
+        )
+        .unwrap();
+
+        let selection = CodexAuthSelection::from_env_or_local_auth_state(&path).unwrap();
+        match selection {
+            CodexAuthSelection::Standalone(state) => {
+                assert_eq!(state.account_id.as_deref(), Some("acct_local"));
+            }
+            _ => panic!("expected standalone selection"),
+        }
+    }
+}

--- a/crates/gateway/src/auth/codex_auth_context.rs
+++ b/crates/gateway/src/auth/codex_auth_context.rs
@@ -3,7 +3,7 @@
 use anyhow::{anyhow, Context, Result};
 use base64::{engine::general_purpose::URL_SAFE_NO_PAD, Engine as _};
 use secrecy::{ExposeSecret, SecretString};
-use std::{env, path::Path};
+use std::{env, path::PathBuf};
 
 use super::codex_auth_state::CodexAuthState;
 
@@ -67,39 +67,48 @@ impl CodexIntegratedAuthHandoff {
 }
 
 #[derive(Debug, Clone)]
-pub enum CodexAuthSelection {
-    Integrated(CodexIntegratedAuthHandoff),
-    Standalone(CodexAuthState),
+pub enum CodexAuthSource {
+    Integrated,
+    StandaloneLocal { path: PathBuf },
 }
 
-impl CodexAuthSelection {
-    pub fn from_env_or_local_auth_state(local_auth_path: impl AsRef<Path>) -> Result<Self> {
-        if let Some(handoff) = CodexIntegratedAuthHandoff::from_env()? {
-            Ok(Self::Integrated(handoff))
-        } else {
-            Ok(Self::Standalone(CodexAuthState::load(local_auth_path)?))
-        }
-    }
-
+impl CodexAuthSource {
     pub fn mode(&self) -> CodexAuthMode {
         match self {
-            Self::Integrated(_) => CodexAuthMode::Integrated,
-            Self::Standalone(_) => CodexAuthMode::Standalone,
+            Self::Integrated => CodexAuthMode::Integrated,
+            Self::StandaloneLocal { .. } => CodexAuthMode::Standalone,
         }
     }
 
-    pub fn resolve(self) -> Result<ResolvedCodexAuthContext> {
+    pub fn resolve(&self) -> Result<ResolvedCodexAuthContext> {
         match self {
-            Self::Integrated(handoff) => resolve_selected_mode(
-                CodexAuthMode::Integrated,
-                handoff.account_id,
-                handoff.access_token,
-            ),
-            Self::Standalone(state) => resolve_selected_mode(
-                CodexAuthMode::Standalone,
-                state.account_id,
-                state.access_token,
-            ),
+            Self::Integrated => {
+                let Some(handoff) = CodexIntegratedAuthHandoff::from_env()? else {
+                    return Err(anyhow!(
+                        "integrated Codex auth source is unavailable: Substrate-delivered auth handoff is missing"
+                    ));
+                };
+
+                resolve_selected_mode(
+                    CodexAuthMode::Integrated,
+                    handoff.account_id,
+                    handoff.access_token,
+                )
+            }
+            Self::StandaloneLocal { path } => {
+                let state = CodexAuthState::load(path).with_context(|| {
+                    format!(
+                        "failed to load standalone Codex auth state from {}",
+                        path.display()
+                    )
+                })?;
+
+                resolve_selected_mode(
+                    CodexAuthMode::Standalone,
+                    state.account_id,
+                    state.access_token,
+                )
+            }
         }
     }
 }
@@ -188,12 +197,12 @@ mod tests {
 
     #[test]
     fn integrated_mode_uses_substrate_account_id_first() {
-        let selection = CodexAuthSelection::Integrated(CodexIntegratedAuthHandoff::new(
+        let resolved = resolve_selected_mode(
+            CodexAuthMode::Integrated,
             Some("acct_explicit".to_string()),
             codex_access_token("acct_jwt"),
-        ));
-
-        let resolved = selection.resolve().unwrap();
+        )
+        .unwrap();
 
         assert_eq!(resolved.mode, CodexAuthMode::Integrated);
         assert_eq!(resolved.account_id, "acct_explicit");
@@ -206,12 +215,12 @@ mod tests {
 
     #[test]
     fn integrated_mode_uses_jwt_fallback_when_explicit_account_id_is_absent() {
-        let selection = CodexAuthSelection::Integrated(CodexIntegratedAuthHandoff::new(
+        let resolved = resolve_selected_mode(
+            CodexAuthMode::Integrated,
             None,
             codex_access_token("acct_jwt"),
-        ));
-
-        let resolved = selection.resolve().unwrap();
+        )
+        .unwrap();
 
         assert_eq!(resolved.mode, CodexAuthMode::Integrated);
         assert_eq!(resolved.account_id, "acct_jwt");
@@ -223,12 +232,12 @@ mod tests {
 
     #[test]
     fn standalone_mode_uses_explicit_account_id_first() {
-        let selection = CodexAuthSelection::Standalone(CodexAuthState::new(
+        let resolved = resolve_selected_mode(
+            CodexAuthMode::Standalone,
             Some("acct_local_explicit".to_string()),
             codex_access_token("acct_local_jwt"),
-        ));
-
-        let resolved = selection.resolve().unwrap();
+        )
+        .unwrap();
 
         assert_eq!(resolved.mode, CodexAuthMode::Standalone);
         assert_eq!(resolved.account_id, "acct_local_explicit");
@@ -237,12 +246,12 @@ mod tests {
 
     #[test]
     fn standalone_mode_uses_jwt_fallback_when_explicit_account_id_is_absent() {
-        let selection = CodexAuthSelection::Standalone(CodexAuthState::new(
+        let resolved = resolve_selected_mode(
+            CodexAuthMode::Standalone,
             None,
             codex_access_token("acct_local_jwt"),
-        ));
-
-        let resolved = selection.resolve().unwrap();
+        )
+        .unwrap();
 
         assert_eq!(resolved.mode, CodexAuthMode::Standalone);
         assert_eq!(resolved.account_id, "acct_local_jwt");
@@ -254,22 +263,21 @@ mod tests {
 
     #[test]
     fn auth_context_resolution_fails_when_account_id_is_unresolvable() {
-        let selection = CodexAuthSelection::Standalone(CodexAuthState::new(
+        let err = resolve_selected_mode(
+            CodexAuthMode::Standalone,
             None,
             SecretString::new("not-a-jwt".to_string()),
-        ));
-
-        let err = selection.resolve().unwrap_err();
+        )
+        .unwrap_err();
         assert!(err
             .to_string()
             .contains("could not resolve account_id from JWT fallback"));
     }
 
     #[test]
-    fn integrated_mode_from_env_uses_canonical_field_names() {
+    fn integrated_source_uses_canonical_field_names() {
         let _env_lock_guard = ENV_LOCK.lock().unwrap();
 
-        let temp_dir = TempDir::new().unwrap();
         let _account_id_guard = EnvGuard::set(
             SUBSTRATE_LLM_BACKEND_AUTH_CLI_CODEX_ACCOUNT_ID,
             "acct_env_explicit",
@@ -279,13 +287,10 @@ mod tests {
             "header.eyJodHRwczovL2FwaS5vcGVuYWkuY29tL2F1dGgiOnsiY2hhdGdwdF9hY2NvdW50X2lkIjoiYWNjdF9lbnZfand0In19.signature",
         );
 
-        let selection = CodexAuthSelection::from_env_or_local_auth_state(temp_dir.path()).unwrap();
-        match selection {
-            CodexAuthSelection::Integrated(handoff) => {
-                assert_eq!(handoff.account_id.as_deref(), Some("acct_env_explicit"));
-            }
-            _ => panic!("expected integrated selection"),
-        }
+        let resolved = CodexAuthSource::Integrated.resolve().unwrap();
+        assert_eq!(resolved.mode, CodexAuthMode::Integrated);
+        assert_eq!(resolved.account_id, "acct_env_explicit");
+        assert_eq!(resolved.account_id_source, CodexAccountIdSource::Explicit);
     }
 
     struct EnvGuard {
@@ -318,7 +323,23 @@ mod tests {
     }
 
     #[test]
-    fn env_selection_falls_back_to_standalone_when_integrated_handoff_is_absent() {
+    fn integrated_source_requires_substrate_handoff() {
+        let _env_lock_guard = ENV_LOCK.lock().unwrap();
+
+        let _account_id_guard = EnvGuard::clear(SUBSTRATE_LLM_BACKEND_AUTH_CLI_CODEX_ACCOUNT_ID);
+        let _access_token_guard =
+            EnvGuard::clear(SUBSTRATE_LLM_BACKEND_AUTH_CLI_CODEX_ACCESS_TOKEN);
+
+        let err = CodexAuthSource::Integrated.resolve().unwrap_err();
+        assert!(
+            err.to_string()
+                .contains("Substrate-delivered auth handoff is missing"),
+            "unexpected error: {err}"
+        );
+    }
+
+    #[test]
+    fn integrated_source_does_not_read_local_auth_files() {
         let _env_lock_guard = ENV_LOCK.lock().unwrap();
 
         let _account_id_guard = EnvGuard::clear(SUBSTRATE_LLM_BACKEND_AUTH_CLI_CODEX_ACCOUNT_ID);
@@ -336,12 +357,30 @@ mod tests {
         )
         .unwrap();
 
-        let selection = CodexAuthSelection::from_env_or_local_auth_state(&path).unwrap();
-        match selection {
-            CodexAuthSelection::Standalone(state) => {
-                assert_eq!(state.account_id.as_deref(), Some("acct_local"));
-            }
-            _ => panic!("expected standalone selection"),
-        }
+        let err = CodexAuthSource::Integrated.resolve().unwrap_err();
+        assert!(
+            err.to_string()
+                .contains("Substrate-delivered auth handoff is missing"),
+            "unexpected error: {err}"
+        );
+    }
+
+    #[test]
+    fn standalone_local_source_uses_explicit_path() {
+        let temp_dir = TempDir::new().unwrap();
+        let path = temp_dir.path().join("auth.json");
+        fs::write(
+            &path,
+            r#"{
+                "account_id": "acct_local",
+                "access_token": "header.eyJodHRwczovL2FwaS5vcGVuYWkuY29tL2F1dGgiOnsiY2hhdGdwdF9hY2NvdW50X2lkIjoiYWNjdF9sb2NhbF9qd3QifX0.signature"
+            }"#,
+        )
+        .unwrap();
+
+        let resolved = CodexAuthSource::StandaloneLocal { path }.resolve().unwrap();
+        assert_eq!(resolved.mode, CodexAuthMode::Standalone);
+        assert_eq!(resolved.account_id, "acct_local");
+        assert_eq!(resolved.account_id_source, CodexAccountIdSource::Explicit);
     }
 }

--- a/crates/gateway/src/auth/codex_auth_state.rs
+++ b/crates/gateway/src/auth/codex_auth_state.rs
@@ -1,0 +1,158 @@
+#![allow(dead_code)]
+
+use anyhow::{Context, Result};
+use secrecy::SecretString;
+use std::{
+    fs,
+    path::{Path, PathBuf},
+};
+
+/// Standalone Codex auth state loaded from a local auth file.
+///
+/// The loader is intentionally liberal about the JSON shape so it can support
+/// the local Codex auth file and equivalent compatibility carriers.
+#[derive(Debug, Clone)]
+pub struct CodexAuthState {
+    pub account_id: Option<String>,
+    pub access_token: SecretString,
+}
+
+impl CodexAuthState {
+    pub fn new(account_id: Option<String>, access_token: SecretString) -> Self {
+        Self {
+            account_id,
+            access_token,
+        }
+    }
+
+    pub fn default_path() -> Result<PathBuf> {
+        let home = dirs::home_dir().context("Failed to get home directory")?;
+        Ok(home.join(".codex").join("auth.json"))
+    }
+
+    pub fn load_default() -> Result<Self> {
+        Self::load(Self::default_path()?)
+    }
+
+    pub fn load(path: impl AsRef<Path>) -> Result<Self> {
+        let path = path.as_ref();
+        let content = fs::read_to_string(path)
+            .with_context(|| format!("Failed to read Codex auth state from {}", path.display()))?;
+        let json: serde_json::Value = serde_json::from_str(&content)
+            .with_context(|| format!("Failed to parse Codex auth state at {}", path.display()))?;
+
+        Self::from_json_value(&json)
+    }
+
+    pub fn from_json_value(value: &serde_json::Value) -> Result<Self> {
+        let account_id = find_string_field(value, &["account_id"]);
+        let access_token = find_string_field(value, &["access_token"])
+            .context("Codex auth state is missing access_token")?;
+
+        Ok(Self::new(account_id, SecretString::new(access_token)))
+    }
+}
+
+fn find_string_field(value: &serde_json::Value, keys: &[&str]) -> Option<String> {
+    match value {
+        serde_json::Value::Object(map) => {
+            for key in keys {
+                if let Some(value) = map.get(*key).and_then(|v| v.as_str()) {
+                    let trimmed = value.trim();
+                    if !trimmed.is_empty() {
+                        return Some(trimmed.to_string());
+                    }
+                }
+            }
+
+            for nested in map.values() {
+                if let Some(found) = find_string_field(nested, keys) {
+                    return Some(found);
+                }
+            }
+
+            None
+        }
+        serde_json::Value::Array(items) => {
+            for item in items {
+                if let Some(found) = find_string_field(item, keys) {
+                    return Some(found);
+                }
+            }
+
+            None
+        }
+        _ => None,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use secrecy::ExposeSecret;
+    use tempfile::TempDir;
+
+    #[test]
+    fn load_codex_auth_state_prefers_explicit_fields() {
+        let temp_dir = TempDir::new().unwrap();
+        let path = temp_dir.path().join("auth.json");
+        fs::write(
+            &path,
+            r#"{
+                "account_id": "acct_local_explicit",
+                "access_token": "header.payload.signature",
+                "oauth": {
+                    "account_id": "acct_nested",
+                    "access_token": "nested-token"
+                }
+            }"#,
+        )
+        .unwrap();
+
+        let state = CodexAuthState::load(&path).unwrap();
+        assert_eq!(state.account_id.as_deref(), Some("acct_local_explicit"));
+        assert_eq!(
+            state.access_token.expose_secret(),
+            "header.payload.signature"
+        );
+    }
+
+    #[test]
+    fn load_codex_auth_state_supports_nested_equivalent_carriers() {
+        let temp_dir = TempDir::new().unwrap();
+        let path = temp_dir.path().join("auth.json");
+        fs::write(
+            &path,
+            r#"{
+                "session": {
+                    "account_id": "acct_nested",
+                    "access_token": "nested.header.signature"
+                }
+            }"#,
+        )
+        .unwrap();
+
+        let state = CodexAuthState::load(&path).unwrap();
+        assert_eq!(state.account_id.as_deref(), Some("acct_nested"));
+        assert_eq!(
+            state.access_token.expose_secret(),
+            "nested.header.signature"
+        );
+    }
+
+    #[test]
+    fn load_codex_auth_state_rejects_missing_access_token() {
+        let temp_dir = TempDir::new().unwrap();
+        let path = temp_dir.path().join("auth.json");
+        fs::write(
+            &path,
+            r#"{
+                "account_id": "acct_local_explicit"
+            }"#,
+        )
+        .unwrap();
+
+        let err = CodexAuthState::load(&path).unwrap_err();
+        assert_eq!(err.to_string(), "Codex auth state is missing access_token");
+    }
+}

--- a/crates/gateway/src/auth/mod.rs
+++ b/crates/gateway/src/auth/mod.rs
@@ -2,5 +2,7 @@ pub mod codex_auth_context;
 pub mod codex_auth_state;
 pub mod oauth;
 pub mod token_store;
+pub use codex_auth_context::ResolvedCodexAuthContext;
+pub use codex_auth_state::CodexAuthState;
 pub use oauth::{OAuthClient, OAuthConfig};
 pub use token_store::TokenStore;

--- a/crates/gateway/src/auth/mod.rs
+++ b/crates/gateway/src/auth/mod.rs
@@ -1,5 +1,6 @@
+pub mod codex_auth_context;
+pub mod codex_auth_state;
 pub mod oauth;
 pub mod token_store;
-
 pub use oauth::{OAuthClient, OAuthConfig};
 pub use token_store::TokenStore;

--- a/crates/gateway/src/auth/mod.rs
+++ b/crates/gateway/src/auth/mod.rs
@@ -2,6 +2,7 @@ pub mod codex_auth_context;
 pub mod codex_auth_state;
 pub mod oauth;
 pub mod token_store;
+pub use codex_auth_context::CodexAuthSource;
 pub use codex_auth_context::ResolvedCodexAuthContext;
 pub use codex_auth_state::CodexAuthState;
 pub use oauth::{OAuthClient, OAuthConfig};

--- a/crates/gateway/src/providers/openai.rs
+++ b/crates/gateway/src/providers/openai.rs
@@ -3657,8 +3657,9 @@ mod tests {
     use base64::engine::general_purpose::URL_SAFE_NO_PAD;
     use secrecy::SecretString;
     use serde::Deserialize;
-    use std::{env, fs, sync::Mutex};
+    use std::{env, fs};
     use tempfile::TempDir;
+    use tokio::sync::Mutex;
 
     static ENV_LOCK: once_cell::sync::Lazy<Mutex<()>> =
         once_cell::sync::Lazy::new(|| Mutex::new(()));
@@ -3826,7 +3827,7 @@ mod tests {
 
     #[test]
     fn codex_auth_resolution_prefers_integrated_env_handoff_before_local_path() {
-        let _guard = ENV_LOCK.lock().unwrap();
+        let _guard = ENV_LOCK.blocking_lock();
         let temp_dir = TempDir::new().unwrap();
         let bogus_home = temp_dir.path().join("home-as-file");
         fs::write(&bogus_home, "not a directory").unwrap();
@@ -4895,7 +4896,7 @@ mod tests {
 
     #[tokio::test(flavor = "current_thread")]
     async fn send_message_validates_codex_route_before_resolving_integrated_auth() {
-        let _guard = ENV_LOCK.lock().unwrap();
+        let _guard = ENV_LOCK.lock().await;
         let provider = test_oauth_provider();
         let original_account_id = env::var_os(
             crate::auth::codex_auth_context::SUBSTRATE_LLM_BACKEND_AUTH_CLI_CODEX_ACCOUNT_ID,

--- a/crates/gateway/src/providers/openai.rs
+++ b/crates/gateway/src/providers/openai.rs
@@ -1,5 +1,7 @@
 use super::{error::ProviderError, OpenAITransport};
-use crate::auth::{OAuthClient, OAuthConfig, TokenStore};
+use crate::auth::{
+    CodexAuthState, OAuthClient, OAuthConfig, ResolvedCodexAuthContext, TokenStore,
+};
 use crate::core::{GatewayRequest, GatewayResponse, GatewayStreamResponse, GatewayUsage};
 use crate::models::{
     ContentBlock, CountTokensRequest, CountTokensResponse, ImageSource, KnownContentBlock,
@@ -1462,15 +1464,46 @@ impl OpenAIProvider {
     fn codex_oauth_request_builder(
         &self,
         req_builder: reqwest::RequestBuilder,
-        auth_value: &str,
+        auth_context: &ResolvedCodexAuthContext,
     ) -> Result<reqwest::RequestBuilder, ProviderError> {
-        let account_id = Self::extract_account_id(auth_value).ok_or_else(|| {
-            ProviderError::AuthError(
-                "OAuth token missing ChatGPT account ID for Codex route".to_string(),
-            )
+        Ok(req_builder.header(
+            "ChatGPT-Account-ID",
+            auth_context.account_id.clone(),
+        ))
+    }
+
+    fn resolve_codex_auth_context(&self) -> Result<ResolvedCodexAuthContext, ProviderError> {
+        if let Some(handoff) = crate::auth::codex_auth_context::CodexIntegratedAuthHandoff::from_env(
+        )
+        .map_err(|e| {
+            ProviderError::AuthError(format!(
+                "Failed to resolve Codex integrated handoff: {}",
+                e
+            ))
+        })? {
+            return crate::auth::codex_auth_context::CodexAuthSelection::Integrated(handoff)
+                .resolve()
+                .map_err(|e| {
+                    ProviderError::AuthError(format!(
+                        "Failed to resolve Codex auth context: {}",
+                        e
+                    ))
+                });
+        }
+
+        let local_auth_path = CodexAuthState::default_path().map_err(|e| {
+            ProviderError::AuthError(format!("Failed to resolve Codex auth path: {}", e))
         })?;
 
-        Ok(req_builder.header("ChatGPT-Account-ID", account_id))
+        crate::auth::codex_auth_context::CodexAuthSelection::Standalone(
+            CodexAuthState::load(local_auth_path).map_err(|e| {
+                ProviderError::AuthError(format!("Failed to load Codex auth state: {}", e))
+            })?,
+        )
+        .resolve()
+        .map_err(|e| {
+            ProviderError::AuthError(format!("Failed to resolve Codex auth context: {}", e))
+        })
     }
 
     fn extract_text_content(content: Option<&OpenAIContent>) -> String {
@@ -2744,13 +2777,15 @@ impl super::GatewayProvider for OpenAIProvider {
         &self,
         request: GatewayRequest,
     ) -> Result<GatewayResponse, ProviderError> {
-        // Get authentication token (API key or OAuth)
-        let auth_value = self.get_auth_header().await?;
-
         // Check if we should use Responses API endpoint:
         // - OAuth: Always use /codex/responses for all models
         // - API Key: Only use /responses for models containing "codex"
         let use_responses_api = self.should_use_responses_api(&request);
+        let codex_auth_context = if self.is_oauth() && use_responses_api {
+            Some(self.resolve_codex_auth_context()?)
+        } else {
+            None
+        };
 
         if use_responses_api {
             // Use /v1/responses endpoint for Codex models
@@ -2766,6 +2801,10 @@ impl super::GatewayProvider for OpenAIProvider {
 
             tracing::debug!("Using {} endpoint for model: {}", endpoint, request.model);
 
+            let auth_value = match codex_auth_context.as_ref() {
+                Some(auth_context) => auth_context.access_token.expose_secret().to_string(),
+                None => self.get_auth_header().await?,
+            };
             let (auth_header_name, auth_header_value) =
                 self.auth_header_parts(&auth_value, self.is_oauth());
             let mut req_builder = self
@@ -2775,8 +2814,8 @@ impl super::GatewayProvider for OpenAIProvider {
                 .header("Content-Type", "application/json");
 
             // For OAuth (ChatGPT Codex), add Codex-specific headers
-            if self.is_oauth() {
-                req_builder = self.codex_oauth_request_builder(req_builder, &auth_value)?;
+            if let Some(auth_context) = codex_auth_context.as_ref() {
+                req_builder = self.codex_oauth_request_builder(req_builder, auth_context)?;
                 tracing::debug!(
                     "🔐 Using OAuth Bearer token for ChatGPT Codex on {}",
                     self.name
@@ -2842,6 +2881,7 @@ impl super::GatewayProvider for OpenAIProvider {
             })
         } else {
             // Use standard /v1/chat/completions endpoint for non-Codex models
+            let auth_value = self.get_auth_header().await?;
             let openai_request = self.transform_request(&request)?;
             let url = self.endpoint_url("/chat/completions");
 
@@ -2959,11 +2999,13 @@ impl super::GatewayProvider for OpenAIProvider {
     ) -> Result<GatewayStreamResponse, ProviderError> {
         use futures::stream::TryStreamExt;
 
-        // Get authentication token (API key or OAuth)
-        let auth_value = self.get_auth_header().await?;
-
         // Check if this is a Codex model
         let use_responses_api = self.should_use_responses_api(&request);
+        let codex_auth_context = if self.is_oauth() && use_responses_api {
+            Some(self.resolve_codex_auth_context()?)
+        } else {
+            None
+        };
 
         let (url, request_body) = if use_responses_api {
             // Use /v1/responses endpoint for Codex models
@@ -2988,6 +3030,11 @@ impl super::GatewayProvider for OpenAIProvider {
             (self.endpoint_url("/chat/completions"), body)
         };
 
+        let auth_value = match codex_auth_context.as_ref() {
+            Some(auth_context) => auth_context.access_token.expose_secret().to_string(),
+            None => self.get_auth_header().await?,
+        };
+
         // Send streaming request
         let (auth_header_name, auth_header_value) =
             self.auth_header_parts(&auth_value, self.is_oauth());
@@ -2999,7 +3046,8 @@ impl super::GatewayProvider for OpenAIProvider {
 
         // For OAuth (ChatGPT Codex), add Codex-specific headers
         if self.is_oauth() && use_responses_api {
-            req_builder = self.codex_oauth_request_builder(req_builder, &auth_value)?;
+            let auth_context = codex_auth_context.as_ref().expect("Codex auth context missing");
+            req_builder = self.codex_oauth_request_builder(req_builder, auth_context)?;
             tracing::debug!(
                 "🔐 Using OAuth Bearer token for ChatGPT Codex streaming on {}",
                 self.name
@@ -3302,9 +3350,19 @@ impl super::GatewayProvider for OpenAIProvider {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::auth::codex_auth_context::CodexAuthSelection;
+    use crate::auth::codex_auth_context::{
+        CodexAccountIdSource, CodexIntegratedAuthHandoff,
+    };
     use crate::models::SystemPrompt;
     use base64::engine::general_purpose::URL_SAFE_NO_PAD;
     use serde::Deserialize;
+    use secrecy::SecretString;
+    use std::{env, fs, sync::Mutex};
+    use tempfile::TempDir;
+
+    static ENV_LOCK: once_cell::sync::Lazy<Mutex<()>> =
+        once_cell::sync::Lazy::new(|| Mutex::new(()));
 
     #[derive(Debug, Deserialize)]
     struct FixtureFile {
@@ -3435,6 +3493,74 @@ mod tests {
             ),
         );
         format!("{header}.{payload}.signature")
+    }
+
+    fn codex_resolved_context(account_id: &str) -> ResolvedCodexAuthContext {
+        CodexAuthSelection::Integrated(CodexIntegratedAuthHandoff::new(
+            Some(account_id.to_string()),
+            SecretString::new(codex_access_token(account_id)),
+        ))
+        .resolve()
+        .unwrap()
+    }
+
+    fn codex_resolved_context_from_selection(
+        selection: CodexAuthSelection,
+    ) -> Result<ResolvedCodexAuthContext, anyhow::Error> {
+        selection.resolve()
+    }
+
+    #[test]
+    fn codex_auth_resolution_prefers_integrated_env_handoff_before_local_path() {
+        let _guard = ENV_LOCK.lock().unwrap();
+        let temp_dir = TempDir::new().unwrap();
+        let bogus_home = temp_dir.path().join("home-as-file");
+        fs::write(&bogus_home, "not a directory").unwrap();
+
+        let original_home = env::var_os("HOME");
+        let original_account_id =
+            env::var_os(crate::auth::codex_auth_context::SUBSTRATE_LLM_BACKEND_AUTH_CLI_CODEX_ACCOUNT_ID);
+        let original_access_token =
+            env::var_os(crate::auth::codex_auth_context::SUBSTRATE_LLM_BACKEND_AUTH_CLI_CODEX_ACCESS_TOKEN);
+
+        env::set_var("HOME", &bogus_home);
+        env::set_var(
+            crate::auth::codex_auth_context::SUBSTRATE_LLM_BACKEND_AUTH_CLI_CODEX_ACCOUNT_ID,
+            "acct_env_explicit",
+        );
+        env::set_var(
+            crate::auth::codex_auth_context::SUBSTRATE_LLM_BACKEND_AUTH_CLI_CODEX_ACCESS_TOKEN,
+            codex_access_token("acct_env_jwt"),
+        );
+
+        let provider = test_oauth_provider();
+        let resolved = provider.resolve_codex_auth_context().unwrap();
+
+        assert_eq!(resolved.account_id, "acct_env_explicit");
+        assert_eq!(resolved.account_id_source, CodexAccountIdSource::Explicit);
+
+        match original_home {
+            Some(value) => env::set_var("HOME", value),
+            None => env::remove_var("HOME"),
+        }
+        match original_account_id {
+            Some(value) => env::set_var(
+                crate::auth::codex_auth_context::SUBSTRATE_LLM_BACKEND_AUTH_CLI_CODEX_ACCOUNT_ID,
+                value,
+            ),
+            None => env::remove_var(
+                crate::auth::codex_auth_context::SUBSTRATE_LLM_BACKEND_AUTH_CLI_CODEX_ACCOUNT_ID,
+            ),
+        }
+        match original_access_token {
+            Some(value) => env::set_var(
+                crate::auth::codex_auth_context::SUBSTRATE_LLM_BACKEND_AUTH_CLI_CODEX_ACCESS_TOKEN,
+                value,
+            ),
+            None => env::remove_var(
+                crate::auth::codex_auth_context::SUBSTRATE_LLM_BACKEND_AUTH_CLI_CODEX_ACCESS_TOKEN,
+            ),
+        }
     }
 
     fn codex_request_with_tool_choice(tool_choice: serde_json::Value) -> GatewayRequest {
@@ -3958,9 +4084,10 @@ mod tests {
     #[test]
     fn codex_oauth_request_builder_emits_only_the_minimal_header_contract() {
         let provider = test_oauth_provider();
-        let auth_value = codex_access_token("acct_123");
-        let expected_auth = format!("Bearer {auth_value}");
-        let (auth_header_name, auth_header_value) = provider.auth_header_parts(&auth_value, true);
+        let auth_context = codex_resolved_context("acct_123");
+        let expected_auth = format!("Bearer {}", auth_context.access_token.expose_secret());
+        let (auth_header_name, auth_header_value) = provider
+            .auth_header_parts(auth_context.access_token.expose_secret(), true);
         let request = provider
             .codex_oauth_request_builder(
                 provider
@@ -3968,7 +4095,7 @@ mod tests {
                     .post("https://example.invalid/v1/responses")
                     .header(auth_header_name, auth_header_value)
                     .header("Content-Type", "application/json"),
-                &auth_value,
+                &auth_context,
             )
             .unwrap()
             .build()
@@ -4005,6 +4132,111 @@ mod tests {
         assert!(headers.get("sec-fetch-dest").is_none());
         assert!(headers.get("sec-fetch-mode").is_none());
         assert!(headers.get("sec-fetch-site").is_none());
+    }
+
+    #[test]
+    fn codex_oauth_request_builder_prefers_explicit_account_id_over_jwt_fallback() {
+        let provider = test_oauth_provider();
+        let selection = CodexAuthSelection::Integrated(CodexIntegratedAuthHandoff::new(
+            Some("acct_explicit".to_string()),
+            SecretString::new(codex_access_token("acct_jwt")),
+        ));
+        let auth_context = codex_resolved_context_from_selection(selection).unwrap();
+        assert_eq!(auth_context.account_id, "acct_explicit");
+        assert_eq!(
+            auth_context.account_id_source,
+            CodexAccountIdSource::Explicit
+        );
+
+        let expected_auth = format!("Bearer {}", auth_context.access_token.expose_secret());
+        let (auth_header_name, auth_header_value) = provider
+            .auth_header_parts(auth_context.access_token.expose_secret(), true);
+        let request = provider
+            .codex_oauth_request_builder(
+                provider
+                    .client
+                    .post("https://example.invalid/v1/responses")
+                    .header(auth_header_name, auth_header_value)
+                    .header("Content-Type", "application/json"),
+                &auth_context,
+            )
+            .unwrap()
+            .build()
+            .unwrap();
+
+        let headers = request.headers();
+        assert_eq!(
+            headers
+                .get("authorization")
+                .and_then(|value| value.to_str().ok()),
+            Some(expected_auth.as_str())
+        );
+        assert_eq!(
+            headers
+                .get("chatgpt-account-id")
+                .and_then(|value| value.to_str().ok()),
+            Some("acct_explicit")
+        );
+    }
+
+    #[test]
+    fn codex_oauth_request_builder_uses_jwt_fallback_only_when_explicit_account_id_is_absent() {
+        let provider = test_oauth_provider();
+        let selection = CodexAuthSelection::Standalone(CodexAuthState::new(
+            None,
+            SecretString::new(codex_access_token("acct_jwt")),
+        ));
+        let auth_context = codex_resolved_context_from_selection(selection).unwrap();
+        assert_eq!(auth_context.account_id, "acct_jwt");
+        assert_eq!(
+            auth_context.account_id_source,
+            CodexAccountIdSource::JwtFallback
+        );
+
+        let expected_auth = format!("Bearer {}", auth_context.access_token.expose_secret());
+        let (auth_header_name, auth_header_value) = provider
+            .auth_header_parts(auth_context.access_token.expose_secret(), true);
+        let request = provider
+            .codex_oauth_request_builder(
+                provider
+                    .client
+                    .post("https://example.invalid/v1/responses")
+                    .header(auth_header_name, auth_header_value)
+                    .header("Content-Type", "application/json"),
+                &auth_context,
+            )
+            .unwrap()
+            .build()
+            .unwrap();
+
+        let headers = request.headers();
+        assert_eq!(
+            headers
+                .get("authorization")
+                .and_then(|value| value.to_str().ok()),
+            Some(expected_auth.as_str())
+        );
+        assert_eq!(
+            headers
+                .get("chatgpt-account-id")
+                .and_then(|value| value.to_str().ok()),
+            Some("acct_jwt")
+        );
+    }
+
+    #[test]
+    fn codex_oauth_request_builder_fails_before_upstream_when_account_id_is_unresolvable() {
+        let selection = CodexAuthSelection::Standalone(CodexAuthState::new(
+            None,
+            SecretString::new("not-a-jwt".to_string()),
+        ));
+
+        let err = codex_resolved_context_from_selection(selection).unwrap_err();
+        assert!(
+            err.to_string()
+                .contains("Codex auth context could not resolve account_id"),
+            "unexpected error: {err}"
+        );
     }
 
     #[test]

--- a/crates/gateway/src/providers/openai.rs
+++ b/crates/gateway/src/providers/openai.rs
@@ -17,6 +17,7 @@ use std::collections::{HashMap, HashSet};
 
 const OPENAI_PARALLEL_TOOL_CALLS_METADATA_KEY: &str = "parallel_tool_calls";
 const OPENAI_PUBLIC_RESPONSES_METADATA_KEY: &str = "openai_public_responses";
+const OPENAI_RESPONSES_TOOL_CHOICE_METADATA_KEY: &str = "openai_responses_tool_choice";
 
 /// Official Codex instructions from OpenAI
 /// Source: https://github.com/openai/codex (rust-v0.58.0)
@@ -72,6 +73,8 @@ struct OpenAIResponsesRequest {
     max_output_tokens: Option<u32>,
     #[serde(skip_serializing_if = "Option::is_none")]
     tools: Option<Vec<OpenAITool>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    tool_choice: Option<serde_json::Value>,
     // Note: ChatGPT Codex does NOT support max_output_tokens, max_tokens, temperature, top_p, stop
 }
 
@@ -612,6 +615,10 @@ impl OpenAIProvider {
         )
     }
 
+    fn codex_responses_endpoint(&self) -> &'static str {
+        "/codex/responses"
+    }
+
     fn auth_header_parts(&self, auth_value: &str, is_oauth: bool) -> (&'static str, String) {
         if is_oauth {
             ("Authorization", format!("Bearer {}", auth_value))
@@ -620,6 +627,20 @@ impl OpenAIProvider {
         } else {
             ("Authorization", format!("Bearer {}", auth_value))
         }
+    }
+
+    fn codex_oauth_request_builder(
+        &self,
+        req_builder: reqwest::RequestBuilder,
+        auth_value: &str,
+    ) -> Result<reqwest::RequestBuilder, ProviderError> {
+        let account_id = Self::extract_account_id(auth_value).ok_or_else(|| {
+            ProviderError::AuthError(
+                "OAuth token missing ChatGPT account ID for Codex route".to_string(),
+            )
+        })?;
+
+        Ok(req_builder.header("ChatGPT-Account-ID", account_id))
     }
 
     fn extract_text_content(content: Option<&OpenAIContent>) -> String {
@@ -983,6 +1004,24 @@ impl OpenAIProvider {
         &self,
         request: &GatewayRequest,
     ) -> Result<OpenAIResponsesRequest, ProviderError> {
+        if self.is_oauth() {
+            if request.temperature.is_some() {
+                return Err(ProviderError::ConfigError(
+                    "temperature is not supported on the Codex route".to_string(),
+                ));
+            }
+            if request.top_p.is_some() {
+                return Err(ProviderError::ConfigError(
+                    "top_p is not supported on the Codex route".to_string(),
+                ));
+            }
+            if request.stop_sequences.is_some() {
+                return Err(ProviderError::ConfigError(
+                    "stop_sequences is not supported on the Codex route".to_string(),
+                ));
+            }
+        }
+
         let mut items = Vec::new();
         let mut synthesized_call_ids = HashSet::new();
 
@@ -1090,6 +1129,12 @@ impl OpenAIProvider {
                 .collect()
         });
 
+        let tool_choice = request
+            .metadata
+            .as_ref()
+            .and_then(|metadata| metadata.get(OPENAI_RESPONSES_TOOL_CHOICE_METADATA_KEY))
+            .cloned();
+
         Ok(OpenAIResponsesRequest {
             model: request.model.clone(),
             input: OpenAIResponsesInput::Items(items),
@@ -1103,6 +1148,7 @@ impl OpenAIProvider {
                 .and_then(|value| value.as_bool()),
             max_output_tokens: (!self.is_oauth()).then_some(request.max_output_tokens),
             tools,
+            tool_choice,
         })
     }
 
@@ -1882,7 +1928,7 @@ impl super::GatewayProvider for OpenAIProvider {
 
             // OAuth (ChatGPT Codex) uses /codex/responses, API Key uses /responses
             let endpoint = if self.is_oauth() {
-                "/codex/responses"
+                self.codex_responses_endpoint()
             } else {
                 "/responses"
             };
@@ -1896,36 +1942,22 @@ impl super::GatewayProvider for OpenAIProvider {
                 .client
                 .post(&url)
                 .header(auth_header_name, auth_header_value)
-                .header("Content-Type", "application/json")
-                .header("accept", "text/event-stream");
+                .header("Content-Type", "application/json");
 
             // For OAuth (ChatGPT Codex), add Codex-specific headers
             if self.is_oauth() {
-                if let Some(account_id) = Self::extract_account_id(&auth_value) {
-                    req_builder = req_builder
-                        .header("chatgpt-account-id", account_id)
-                        .header("OpenAI-Beta", "responses=experimental")
-                        .header("originator", "codex_cli_rs")
-                        // Browser-like headers to avoid Cloudflare bot detection
-                        .header("User-Agent", "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/131.0.0.0 Safari/537.36")
-                        .header("Origin", "https://chatgpt.com")
-                        .header("Referer", "https://chatgpt.com/")
-                        .header("sec-ch-ua", "\"Google Chrome\";v=\"131\", \"Chromium\";v=\"131\", \"Not_A Brand\";v=\"24\"")
-                        .header("sec-ch-ua-mobile", "?0")
-                        .header("sec-ch-ua-platform", "\"macOS\"")
-                        .header("sec-fetch-dest", "empty")
-                        .header("sec-fetch-mode", "cors")
-                        .header("sec-fetch-site", "same-origin");
-                    tracing::debug!(
-                        "🔐 Using OAuth Bearer token for ChatGPT Codex on {}",
-                        self.name
-                    );
-                }
+                req_builder = self.codex_oauth_request_builder(req_builder, &auth_value)?;
+                tracing::debug!(
+                    "🔐 Using OAuth Bearer token for ChatGPT Codex on {}",
+                    self.name
+                );
             }
 
-            // Add custom headers
-            for (key, value) in &self.custom_headers {
-                req_builder = req_builder.header(key, value);
+            if !(self.is_oauth() && use_responses_api) {
+                // Add custom headers for non-Codex routes only.
+                for (key, value) in &self.custom_headers {
+                    req_builder = req_builder.header(key, value);
+                }
             }
 
             let response = req_builder.json(&responses_request).send().await?;
@@ -2101,7 +2133,12 @@ impl super::GatewayProvider for OpenAIProvider {
             let responses_request = self.transform_to_responses_request(&request)?;
             let body = serde_json::to_value(&responses_request)
                 .map_err(ProviderError::SerializationError)?;
-            (self.endpoint_url("/responses"), body)
+            let endpoint = if self.is_oauth() {
+                self.codex_responses_endpoint()
+            } else {
+                "/responses"
+            };
+            (self.endpoint_url(endpoint), body)
         } else {
             // Use standard /v1/chat/completions endpoint
             let openai_request = self.transform_request(&request)?;
@@ -2117,21 +2154,15 @@ impl super::GatewayProvider for OpenAIProvider {
             .client
             .post(&url)
             .header(auth_header_name, auth_header_value)
-            .header("Content-Type", "application/json")
-            .header("accept", "text/event-stream");
+            .header("Content-Type", "application/json");
 
         // For OAuth (ChatGPT Codex), add Codex-specific headers
         if self.is_oauth() && use_responses_api {
-            if let Some(account_id) = Self::extract_account_id(&auth_value) {
-                req_builder = req_builder
-                    .header("chatgpt-account-id", account_id)
-                    .header("OpenAI-Beta", "responses=experimental")
-                    .header("originator", "codex_cli_rs");
-                tracing::debug!(
-                    "🔐 Using OAuth Bearer token for ChatGPT Codex streaming on {}",
-                    self.name
-                );
-            }
+            req_builder = self.codex_oauth_request_builder(req_builder, &auth_value)?;
+            tracing::debug!(
+                "🔐 Using OAuth Bearer token for ChatGPT Codex streaming on {}",
+                self.name
+            );
         } else if self.is_oauth() {
             // For non-Codex OAuth (if needed in the future)
             if let Some(account_id) = Self::extract_account_id(&auth_value) {
@@ -2140,9 +2171,11 @@ impl super::GatewayProvider for OpenAIProvider {
             }
         }
 
-        // Add custom headers (for OpenRouter, NovitaAI, etc.)
-        for (key, value) in &self.custom_headers {
-            req_builder = req_builder.header(key, value);
+        if !(self.is_oauth() && use_responses_api) {
+            // Add custom headers for non-Codex routes only.
+            for (key, value) in &self.custom_headers {
+                req_builder = req_builder.header(key, value);
+            }
         }
 
         let response = req_builder.json(&request_body).send().await?;
@@ -2367,6 +2400,7 @@ impl super::GatewayProvider for OpenAIProvider {
 mod tests {
     use super::*;
     use crate::models::SystemPrompt;
+    use base64::engine::general_purpose::URL_SAFE_NO_PAD;
     use serde::Deserialize;
 
     #[derive(Debug, Deserialize)]
@@ -2485,6 +2519,49 @@ mod tests {
             custom_headers: Vec::new(),
             oauth_provider: Some("test-oauth-provider".to_string()),
             token_store: Some(token_store),
+        }
+    }
+
+    fn codex_access_token(account_id: &str) -> String {
+        let header = base64::Engine::encode(&URL_SAFE_NO_PAD, r#"{"alg":"none","typ":"JWT"}"#);
+        let payload = base64::Engine::encode(
+            &URL_SAFE_NO_PAD,
+            format!(
+                r#"{{"https://api.openai.com/auth":{{"chatgpt_account_id":"{}"}}}}"#,
+                account_id
+            ),
+        );
+        format!("{header}.{payload}.signature")
+    }
+
+    fn codex_request_with_tool_choice(tool_choice: serde_json::Value) -> GatewayRequest {
+        let mut metadata = HashMap::new();
+        metadata.insert(
+            OPENAI_RESPONSES_TOOL_CHOICE_METADATA_KEY.to_string(),
+            tool_choice,
+        );
+
+        GatewayRequest {
+            model: "gpt-test".to_string(),
+            messages: vec![crate::models::Message {
+                role: "user".to_string(),
+                content: crate::models::MessageContent::Text("hello".to_string()),
+            }],
+            max_output_tokens: 32,
+            reasoning: None,
+            temperature: None,
+            top_p: None,
+            top_k: None,
+            stop_sequences: None,
+            stream: Some(false),
+            metadata: Some(metadata),
+            system: None,
+            tools: Some(vec![crate::models::Tool {
+                r#type: Some("function".to_string()),
+                name: Some("lookup".to_string()),
+                description: None,
+                input_schema: None,
+            }]),
         }
     }
 
@@ -2670,6 +2747,17 @@ mod tests {
         assert_eq!(
             provider.endpoint_url("/chat/completions"),
             "https://chatgpt.com/backend-api/chat/completions"
+        );
+    }
+
+    #[test]
+    fn codex_oauth_routes_share_the_codex_responses_endpoint() {
+        let provider = test_oauth_provider();
+
+        assert_eq!(provider.codex_responses_endpoint(), "/codex/responses");
+        assert_eq!(
+            provider.endpoint_url(provider.codex_responses_endpoint()),
+            "https://chatgpt.com/backend-api/codex/responses"
         );
     }
 
@@ -2938,6 +3026,132 @@ mod tests {
         assert_eq!(input[2]["output"], serde_json::json!("{\"ok\":true}"));
         assert!(serialized.get("instructions").is_none());
         assert!(serialized.get("store").is_none());
+    }
+
+    #[test]
+    fn transform_to_responses_request_carries_explicit_tool_choice_from_metadata() {
+        let provider = test_oauth_provider();
+        let request = codex_request_with_tool_choice(serde_json::json!({
+            "type": "function",
+            "function": {
+                "name": "lookup"
+            }
+        }));
+
+        let openai_request = provider.transform_to_responses_request(&request).unwrap();
+        let serialized = serde_json::to_value(openai_request).unwrap();
+
+        assert_eq!(
+            serialized["tool_choice"],
+            serde_json::json!({
+                "type": "function",
+                "function": {
+                    "name": "lookup"
+                }
+            })
+        );
+    }
+
+    #[test]
+    fn codex_oauth_request_builder_emits_only_the_minimal_header_contract() {
+        let provider = test_oauth_provider();
+        let auth_value = codex_access_token("acct_123");
+        let expected_auth = format!("Bearer {auth_value}");
+        let (auth_header_name, auth_header_value) = provider.auth_header_parts(&auth_value, true);
+        let request = provider
+            .codex_oauth_request_builder(
+                provider
+                    .client
+                    .post("https://example.invalid/v1/responses")
+                    .header(auth_header_name, auth_header_value)
+                    .header("Content-Type", "application/json"),
+                &auth_value,
+            )
+            .unwrap()
+            .build()
+            .unwrap();
+
+        let headers = request.headers();
+        assert_eq!(
+            headers
+                .get("authorization")
+                .and_then(|value| value.to_str().ok()),
+            Some(expected_auth.as_str())
+        );
+        assert_eq!(
+            headers
+                .get("chatgpt-account-id")
+                .and_then(|value| value.to_str().ok()),
+            Some("acct_123")
+        );
+        assert_eq!(
+            headers
+                .get("content-type")
+                .and_then(|value| value.to_str().ok()),
+            Some("application/json")
+        );
+        assert!(headers.get("accept").is_none());
+        assert!(headers.get("openai-beta").is_none());
+        assert!(headers.get("originator").is_none());
+        assert!(headers.get("user-agent").is_none());
+        assert!(headers.get("origin").is_none());
+        assert!(headers.get("referer").is_none());
+        assert!(headers.get("sec-ch-ua").is_none());
+        assert!(headers.get("sec-ch-ua-mobile").is_none());
+        assert!(headers.get("sec-ch-ua-platform").is_none());
+        assert!(headers.get("sec-fetch-dest").is_none());
+        assert!(headers.get("sec-fetch-mode").is_none());
+        assert!(headers.get("sec-fetch-site").is_none());
+    }
+
+    #[test]
+    fn transform_to_responses_request_rejects_unsupported_codex_controls() {
+        let provider = test_oauth_provider();
+        for (field, request) in [
+            (
+                "temperature",
+                GatewayRequest {
+                    temperature: Some(0.2),
+                    ..codex_request_with_tool_choice(serde_json::json!({
+                        "type": "function",
+                        "function": { "name": "lookup" }
+                    }))
+                },
+            ),
+            (
+                "top_p",
+                GatewayRequest {
+                    top_p: Some(0.5),
+                    ..codex_request_with_tool_choice(serde_json::json!({
+                        "type": "function",
+                        "function": { "name": "lookup" }
+                    }))
+                },
+            ),
+            (
+                "stop_sequences",
+                GatewayRequest {
+                    stop_sequences: Some(vec!["done".to_string()]),
+                    ..codex_request_with_tool_choice(serde_json::json!({
+                        "type": "function",
+                        "function": { "name": "lookup" }
+                    }))
+                },
+            ),
+        ] {
+            let err = provider
+                .transform_to_responses_request(&request)
+                .unwrap_err();
+            match err {
+                ProviderError::ConfigError(message) => {
+                    assert!(
+                        message.contains(field),
+                        "expected reject message to mention {field}, got {message}"
+                    );
+                }
+                other => panic!("expected config error for {field}, got {other:?}"),
+            }
+        }
     }
 
     #[test]

--- a/crates/gateway/src/providers/openai.rs
+++ b/crates/gateway/src/providers/openai.rs
@@ -2061,6 +2061,12 @@ impl OpenAIProvider {
             }
         }
 
+        let allows_previous_response_continuation = request
+            .metadata
+            .as_ref()
+            .and_then(|metadata| metadata.get(OPENAI_RESPONSES_PREVIOUS_RESPONSE_ID_METADATA_KEY))
+            .and_then(|value| value.as_str())
+            .is_some();
         let mut items = Vec::new();
         let mut emitted_call_ids = HashSet::new();
         let mut authoritative_provenance = HashMap::new();
@@ -2123,20 +2129,21 @@ impl OpenAIProvider {
                                     &mut content_parts,
                                 );
                                 if !emitted_call_ids.contains(tool_use_id) {
-                                    let Some((name, arguments)) =
+                                    if let Some((name, arguments)) =
                                         authoritative_provenance.get(tool_use_id).cloned()
-                                    else {
+                                    {
+                                        emitted_call_ids.insert(tool_use_id.clone());
+                                        items.push(OpenAIResponsesInputItem::FunctionCall {
+                                            call_id: tool_use_id.clone(),
+                                            name,
+                                            arguments,
+                                        });
+                                    } else if !allows_previous_response_continuation {
                                         return Err(ProviderError::ConfigError(
                                             "Responses continuation requires authoritative provenance for each function_call_output"
                                                 .to_string(),
                                         ));
-                                    };
-                                    emitted_call_ids.insert(tool_use_id.clone());
-                                    items.push(OpenAIResponsesInputItem::FunctionCall {
-                                        call_id: tool_use_id.clone(),
-                                        name,
-                                        arguments,
-                                    });
+                                    }
                                 }
                                 let output = if *is_error {
                                     tracing::debug!(
@@ -4152,6 +4159,45 @@ mod tests {
         }
     }
 
+    fn previous_response_id_public_responses_continuation_request() -> GatewayRequest {
+        let mut metadata = HashMap::new();
+        metadata.insert(
+            OPENAI_PUBLIC_RESPONSES_METADATA_KEY.to_string(),
+            serde_json::Value::Bool(true),
+        );
+        metadata.insert(
+            OPENAI_RESPONSES_PREVIOUS_RESPONSE_ID_METADATA_KEY.to_string(),
+            serde_json::Value::String("resp_prev_123".to_string()),
+        );
+
+        GatewayRequest {
+            model: "gpt-4.1-mini".to_string(),
+            messages: vec![crate::models::Message {
+                role: "user".to_string(),
+                content: crate::models::MessageContent::Blocks(vec![ContentBlock::Known(
+                    KnownContentBlock::ToolResult {
+                        tool_use_id: "call_fixture_1".to_string(),
+                        content: crate::models::ToolResultContent::Text(
+                            "{\"ok\":true}".to_string(),
+                        ),
+                        is_error: false,
+                        cache_control: None,
+                    },
+                )]),
+            }],
+            max_output_tokens: 32,
+            reasoning: None,
+            temperature: None,
+            top_p: None,
+            top_k: None,
+            stop_sequences: None,
+            stream: Some(false),
+            metadata: Some(metadata),
+            system: None,
+            tools: None,
+        }
+    }
+
     fn orphaned_public_responses_continuation_request() -> GatewayRequest {
         let mut metadata = HashMap::new();
         metadata.insert(
@@ -4558,6 +4604,28 @@ mod tests {
             }
             other => panic!("expected config error, got {other:?}"),
         }
+    }
+
+    #[test]
+    fn transform_to_responses_request_preserves_previous_response_id_output_only_continuations() {
+        let provider = test_provider(OpenAITransport::OpenAI);
+        let request = previous_response_id_public_responses_continuation_request();
+
+        let serialized =
+            serde_json::to_value(provider.transform_to_responses_request(&request).unwrap())
+                .unwrap();
+        let input = serialized["input"]
+            .as_array()
+            .expect("responses input array");
+
+        assert_eq!(
+            serialized["previous_response_id"],
+            serde_json::json!("resp_prev_123")
+        );
+        assert_eq!(input.len(), 1);
+        assert_eq!(input[0]["type"], serde_json::json!("function_call_output"));
+        assert_eq!(input[0]["call_id"], serde_json::json!("call_fixture_1"));
+        assert_eq!(input[0]["output"], serde_json::json!("{\"ok\":true}"));
     }
 
     #[test]

--- a/crates/gateway/src/providers/openai.rs
+++ b/crates/gateway/src/providers/openai.rs
@@ -1,7 +1,5 @@
 use super::{error::ProviderError, OpenAITransport};
-use crate::auth::{
-    CodexAuthState, OAuthClient, OAuthConfig, ResolvedCodexAuthContext, TokenStore,
-};
+use crate::auth::{CodexAuthState, OAuthClient, OAuthConfig, ResolvedCodexAuthContext, TokenStore};
 use crate::core::{GatewayRequest, GatewayResponse, GatewayStreamResponse, GatewayUsage};
 use crate::models::{
     ContentBlock, CountTokensRequest, CountTokensResponse, ImageSource, KnownContentBlock,
@@ -1466,28 +1464,24 @@ impl OpenAIProvider {
         req_builder: reqwest::RequestBuilder,
         auth_context: &ResolvedCodexAuthContext,
     ) -> Result<reqwest::RequestBuilder, ProviderError> {
-        Ok(req_builder.header(
-            "ChatGPT-Account-ID",
-            auth_context.account_id.clone(),
-        ))
+        Ok(req_builder.header("ChatGPT-Account-ID", auth_context.account_id.clone()))
     }
 
     fn resolve_codex_auth_context(&self) -> Result<ResolvedCodexAuthContext, ProviderError> {
-        if let Some(handoff) = crate::auth::codex_auth_context::CodexIntegratedAuthHandoff::from_env(
-        )
-        .map_err(|e| {
-            ProviderError::AuthError(format!(
-                "Failed to resolve Codex integrated handoff: {}",
-                e
-            ))
-        })? {
+        if let Some(handoff) =
+            crate::auth::codex_auth_context::CodexIntegratedAuthHandoff::from_env().map_err(
+                |e| {
+                    ProviderError::AuthError(format!(
+                        "Failed to resolve Codex integrated handoff: {}",
+                        e
+                    ))
+                },
+            )?
+        {
             return crate::auth::codex_auth_context::CodexAuthSelection::Integrated(handoff)
                 .resolve()
                 .map_err(|e| {
-                    ProviderError::AuthError(format!(
-                        "Failed to resolve Codex auth context: {}",
-                        e
-                    ))
+                    ProviderError::AuthError(format!("Failed to resolve Codex auth context: {}", e))
                 });
         }
 
@@ -3046,7 +3040,9 @@ impl super::GatewayProvider for OpenAIProvider {
 
         // For OAuth (ChatGPT Codex), add Codex-specific headers
         if self.is_oauth() && use_responses_api {
-            let auth_context = codex_auth_context.as_ref().expect("Codex auth context missing");
+            let auth_context = codex_auth_context
+                .as_ref()
+                .expect("Codex auth context missing");
             req_builder = self.codex_oauth_request_builder(req_builder, auth_context)?;
             tracing::debug!(
                 "🔐 Using OAuth Bearer token for ChatGPT Codex streaming on {}",
@@ -3351,13 +3347,11 @@ impl super::GatewayProvider for OpenAIProvider {
 mod tests {
     use super::*;
     use crate::auth::codex_auth_context::CodexAuthSelection;
-    use crate::auth::codex_auth_context::{
-        CodexAccountIdSource, CodexIntegratedAuthHandoff,
-    };
+    use crate::auth::codex_auth_context::{CodexAccountIdSource, CodexIntegratedAuthHandoff};
     use crate::models::SystemPrompt;
     use base64::engine::general_purpose::URL_SAFE_NO_PAD;
-    use serde::Deserialize;
     use secrecy::SecretString;
+    use serde::Deserialize;
     use std::{env, fs, sync::Mutex};
     use tempfile::TempDir;
 
@@ -3518,10 +3512,12 @@ mod tests {
         fs::write(&bogus_home, "not a directory").unwrap();
 
         let original_home = env::var_os("HOME");
-        let original_account_id =
-            env::var_os(crate::auth::codex_auth_context::SUBSTRATE_LLM_BACKEND_AUTH_CLI_CODEX_ACCOUNT_ID);
-        let original_access_token =
-            env::var_os(crate::auth::codex_auth_context::SUBSTRATE_LLM_BACKEND_AUTH_CLI_CODEX_ACCESS_TOKEN);
+        let original_account_id = env::var_os(
+            crate::auth::codex_auth_context::SUBSTRATE_LLM_BACKEND_AUTH_CLI_CODEX_ACCOUNT_ID,
+        );
+        let original_access_token = env::var_os(
+            crate::auth::codex_auth_context::SUBSTRATE_LLM_BACKEND_AUTH_CLI_CODEX_ACCESS_TOKEN,
+        );
 
         env::set_var("HOME", &bogus_home);
         env::set_var(
@@ -4086,8 +4082,8 @@ mod tests {
         let provider = test_oauth_provider();
         let auth_context = codex_resolved_context("acct_123");
         let expected_auth = format!("Bearer {}", auth_context.access_token.expose_secret());
-        let (auth_header_name, auth_header_value) = provider
-            .auth_header_parts(auth_context.access_token.expose_secret(), true);
+        let (auth_header_name, auth_header_value) =
+            provider.auth_header_parts(auth_context.access_token.expose_secret(), true);
         let request = provider
             .codex_oauth_request_builder(
                 provider
@@ -4149,8 +4145,8 @@ mod tests {
         );
 
         let expected_auth = format!("Bearer {}", auth_context.access_token.expose_secret());
-        let (auth_header_name, auth_header_value) = provider
-            .auth_header_parts(auth_context.access_token.expose_secret(), true);
+        let (auth_header_name, auth_header_value) =
+            provider.auth_header_parts(auth_context.access_token.expose_secret(), true);
         let request = provider
             .codex_oauth_request_builder(
                 provider
@@ -4194,8 +4190,8 @@ mod tests {
         );
 
         let expected_auth = format!("Bearer {}", auth_context.access_token.expose_secret());
-        let (auth_header_name, auth_header_value) = provider
-            .auth_header_parts(auth_context.access_token.expose_secret(), true);
+        let (auth_header_name, auth_header_value) =
+            provider.auth_header_parts(auth_context.access_token.expose_secret(), true);
         let request = provider
             .codex_oauth_request_builder(
                 provider

--- a/crates/gateway/src/providers/openai.rs
+++ b/crates/gateway/src/providers/openai.rs
@@ -20,6 +20,19 @@ use crate::providers::streaming::{parse_sse_events, SseEvent, SseStream};
 const OPENAI_PARALLEL_TOOL_CALLS_METADATA_KEY: &str = "parallel_tool_calls";
 const OPENAI_PUBLIC_RESPONSES_METADATA_KEY: &str = "openai_public_responses";
 const OPENAI_RESPONSES_TOOL_CHOICE_METADATA_KEY: &str = "openai_responses_tool_choice";
+const OPENAI_RESPONSES_REASONING_EFFORT_METADATA_KEY: &str = "openai_responses_reasoning_effort";
+const OPENAI_RESPONSES_REASONING_SUMMARY_METADATA_KEY: &str = "openai_responses_reasoning_summary";
+const OPENAI_RESPONSES_INCLUDE_METADATA_KEY: &str = "openai_responses_include";
+const OPENAI_RESPONSES_TEXT_VERBOSITY_METADATA_KEY: &str = "openai_responses_text_verbosity";
+const OPENAI_RESPONSES_EXPLICIT_MAX_OUTPUT_TOKENS_METADATA_KEY: &str =
+    "openai_responses_explicit_max_output_tokens";
+const OPENAI_RESPONSES_INPUT_METADATA_METADATA_KEY: &str = "openai_responses_input_metadata";
+const OPENAI_RESPONSES_TRUNCATION_METADATA_KEY: &str = "openai_responses_truncation";
+const OPENAI_RESPONSES_PREVIOUS_RESPONSE_ID_METADATA_KEY: &str =
+    "openai_responses_previous_response_id";
+const OPENAI_RESPONSES_USER_METADATA_KEY: &str = "openai_responses_user";
+const OPENAI_RESPONSES_STREAM_OPTIONS_METADATA_KEY: &str = "openai_responses_stream_options";
+const OPENAI_RESPONSES_SERVICE_TIER_METADATA_KEY: &str = "openai_responses_service_tier";
 
 /// Official Codex instructions from OpenAI
 /// Source: https://github.com/openai/codex (rust-v0.58.0)
@@ -73,6 +86,12 @@ struct OpenAIResponsesRequest {
     parallel_tool_calls: Option<bool>,
     #[serde(skip_serializing_if = "Option::is_none")]
     max_output_tokens: Option<u32>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    reasoning: Option<serde_json::Value>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    include: Option<Vec<String>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    text: Option<serde_json::Value>,
     #[serde(skip_serializing_if = "Option::is_none")]
     tools: Option<Vec<OpenAITool>>,
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -556,6 +575,27 @@ fn codex_transport_drift(message: impl Into<String>) -> ProviderError {
         status: 502,
         message: message.into(),
     }
+}
+
+fn flatten_responses_tool_choice(tool_choice: &serde_json::Value) -> serde_json::Value {
+    let Some(obj) = tool_choice.as_object() else {
+        return tool_choice.clone();
+    };
+    if obj.get("type").and_then(|value| value.as_str()) != Some("function") {
+        return tool_choice.clone();
+    }
+    let Some(name) = obj
+        .get("function")
+        .and_then(|value| value.get("name"))
+        .and_then(|value| value.as_str())
+    else {
+        return tool_choice.clone();
+    };
+
+    serde_json::json!({
+        "type": "function",
+        "name": name
+    })
 }
 
 fn codex_semantic_output_index(json: &serde_json::Value) -> Result<usize, ProviderError> {
@@ -1877,6 +1917,153 @@ impl OpenAIProvider {
                     "stop_sequences is not supported on the Codex route".to_string(),
                 ));
             }
+            if request.metadata.as_ref().is_some_and(|metadata| {
+                metadata.contains_key(OPENAI_RESPONSES_EXPLICIT_MAX_OUTPUT_TOKENS_METADATA_KEY)
+            }) {
+                return Err(ProviderError::ConfigError(
+                    "max_output_tokens is not supported on the Codex route".to_string(),
+                ));
+            }
+            if request.metadata.as_ref().is_some_and(|metadata| {
+                metadata.contains_key(OPENAI_RESPONSES_INPUT_METADATA_METADATA_KEY)
+            }) {
+                return Err(ProviderError::ConfigError(
+                    "metadata is not supported on the Codex route".to_string(),
+                ));
+            }
+            if request.metadata.as_ref().is_some_and(|metadata| {
+                metadata.contains_key(OPENAI_RESPONSES_TRUNCATION_METADATA_KEY)
+            }) {
+                return Err(ProviderError::ConfigError(
+                    "truncation is not supported on the Codex route".to_string(),
+                ));
+            }
+            if request.metadata.as_ref().is_some_and(|metadata| {
+                metadata.contains_key(OPENAI_RESPONSES_PREVIOUS_RESPONSE_ID_METADATA_KEY)
+            }) {
+                return Err(ProviderError::ConfigError(
+                    "previous_response_id is not supported on the Codex route".to_string(),
+                ));
+            }
+            if request
+                .metadata
+                .as_ref()
+                .is_some_and(|metadata| metadata.contains_key(OPENAI_RESPONSES_USER_METADATA_KEY))
+            {
+                return Err(ProviderError::ConfigError(
+                    "user is not supported on the Codex route".to_string(),
+                ));
+            }
+            if request.metadata.as_ref().is_some_and(|metadata| {
+                metadata.contains_key(OPENAI_RESPONSES_STREAM_OPTIONS_METADATA_KEY)
+            }) {
+                return Err(ProviderError::ConfigError(
+                    "stream_options is not supported on the Codex route".to_string(),
+                ));
+            }
+            if request.metadata.as_ref().is_some_and(|metadata| {
+                metadata.contains_key(OPENAI_RESPONSES_SERVICE_TIER_METADATA_KEY)
+            }) {
+                return Err(ProviderError::ConfigError(
+                    "service_tier is not supported on the Codex route".to_string(),
+                ));
+            }
+            if let Some(tool_choice) = request
+                .metadata
+                .as_ref()
+                .and_then(|metadata| metadata.get(OPENAI_RESPONSES_TOOL_CHOICE_METADATA_KEY))
+                .and_then(|value| value.as_str())
+            {
+                if tool_choice == "required" {
+                    return Err(ProviderError::ConfigError(
+                        "tool_choice=\"required\" is not supported on the Codex route".to_string(),
+                    ));
+                }
+            }
+            if let Some(reasoning_effort) = request
+                .metadata
+                .as_ref()
+                .and_then(|metadata| metadata.get(OPENAI_RESPONSES_REASONING_EFFORT_METADATA_KEY))
+                .and_then(|value| value.as_str())
+            {
+                if !matches!(
+                    reasoning_effort,
+                    "none" | "minimal" | "low" | "medium" | "high" | "xhigh"
+                ) {
+                    return Err(ProviderError::ConfigError(
+                        "Unsupported reasoning.effort on the Codex route".to_string(),
+                    ));
+                }
+            }
+            if let Some(reasoning_summary) = request
+                .metadata
+                .as_ref()
+                .and_then(|metadata| metadata.get(OPENAI_RESPONSES_REASONING_SUMMARY_METADATA_KEY))
+                .and_then(|value| value.as_str())
+            {
+                if !matches!(reasoning_summary, "auto" | "concise" | "detailed" | "none") {
+                    return Err(ProviderError::ConfigError(
+                        "Unsupported reasoning.summary on the Codex route".to_string(),
+                    ));
+                }
+                let reasoning_enabled = request
+                    .metadata
+                    .as_ref()
+                    .and_then(|metadata| {
+                        metadata.get(OPENAI_RESPONSES_REASONING_EFFORT_METADATA_KEY)
+                    })
+                    .and_then(|value| value.as_str())
+                    .is_some_and(|effort| effort != "none");
+                if reasoning_summary != "none" && !reasoning_enabled {
+                    return Err(ProviderError::ConfigError(
+                        "reasoning.summary requires reasoning.effort to be enabled on the Codex route"
+                            .to_string(),
+                    ));
+                }
+            }
+            if let Some(include) = request
+                .metadata
+                .as_ref()
+                .and_then(|metadata| metadata.get(OPENAI_RESPONSES_INCLUDE_METADATA_KEY))
+                .and_then(|value| value.as_array())
+            {
+                let include_values: Vec<&str> =
+                    include.iter().filter_map(|value| value.as_str()).collect();
+                if !(include_values.is_empty()
+                    || (include_values.len() == 1
+                        && include_values[0] == "reasoning.encrypted_content"))
+                {
+                    return Err(ProviderError::ConfigError(
+                        "Unsupported include value on the Codex route".to_string(),
+                    ));
+                }
+                let reasoning_enabled = request
+                    .metadata
+                    .as_ref()
+                    .and_then(|metadata| {
+                        metadata.get(OPENAI_RESPONSES_REASONING_EFFORT_METADATA_KEY)
+                    })
+                    .and_then(|value| value.as_str())
+                    .is_some_and(|effort| effort != "none");
+                if !include_values.is_empty() && !reasoning_enabled {
+                    return Err(ProviderError::ConfigError(
+                        "include reasoning.encrypted_content requires reasoning.effort to be enabled on the Codex route"
+                            .to_string(),
+                    ));
+                }
+            }
+            if let Some(verbosity) = request
+                .metadata
+                .as_ref()
+                .and_then(|metadata| metadata.get(OPENAI_RESPONSES_TEXT_VERBOSITY_METADATA_KEY))
+                .and_then(|value| value.as_str())
+            {
+                if !matches!(verbosity, "low" | "medium" | "high") {
+                    return Err(ProviderError::ConfigError(
+                        "Unsupported text.verbosity on the Codex route".to_string(),
+                    ));
+                }
+            }
         }
 
         let mut items = Vec::new();
@@ -1990,7 +2177,60 @@ impl OpenAIProvider {
             .metadata
             .as_ref()
             .and_then(|metadata| metadata.get(OPENAI_RESPONSES_TOOL_CHOICE_METADATA_KEY))
-            .cloned();
+            .map(flatten_responses_tool_choice);
+
+        let reasoning_effort = request
+            .metadata
+            .as_ref()
+            .and_then(|metadata| metadata.get(OPENAI_RESPONSES_REASONING_EFFORT_METADATA_KEY))
+            .and_then(|value| value.as_str());
+        let reasoning_summary = request
+            .metadata
+            .as_ref()
+            .and_then(|metadata| metadata.get(OPENAI_RESPONSES_REASONING_SUMMARY_METADATA_KEY))
+            .and_then(|value| value.as_str());
+        let reasoning = reasoning_effort.map(|effort| {
+            let mut reasoning = serde_json::Map::new();
+            reasoning.insert(
+                "effort".to_string(),
+                serde_json::Value::String(effort.to_string()),
+            );
+            if let Some(summary) = reasoning_summary {
+                reasoning.insert(
+                    "summary".to_string(),
+                    serde_json::Value::String(summary.to_string()),
+                );
+            }
+            serde_json::Value::Object(reasoning)
+        });
+
+        let include = request
+            .metadata
+            .as_ref()
+            .and_then(|metadata| metadata.get(OPENAI_RESPONSES_INCLUDE_METADATA_KEY))
+            .and_then(|value| value.as_array())
+            .map(|items| {
+                items
+                    .iter()
+                    .filter_map(|value| value.as_str().map(ToString::to_string))
+                    .collect::<Vec<_>>()
+            });
+
+        let text = request
+            .metadata
+            .as_ref()
+            .and_then(|metadata| metadata.get(OPENAI_RESPONSES_TEXT_VERBOSITY_METADATA_KEY))
+            .and_then(|value| value.as_str())
+            .map(|verbosity| {
+                serde_json::json!({
+                    "format": { "type": "text" },
+                    "verbosity": verbosity
+                })
+            })
+            .or_else(|| {
+                self.is_oauth()
+                    .then_some(serde_json::json!({ "format": { "type": "text" } }))
+            });
 
         Ok(OpenAIResponsesRequest {
             model: request.model.clone(),
@@ -2004,6 +2244,9 @@ impl OpenAIProvider {
                 .and_then(|metadata| metadata.get(OPENAI_PARALLEL_TOOL_CALLS_METADATA_KEY))
                 .and_then(|value| value.as_bool()),
             max_output_tokens: (!self.is_oauth()).then_some(request.max_output_tokens),
+            reasoning,
+            include,
+            text,
             tools,
             tool_choice,
         })
@@ -3662,6 +3905,77 @@ mod tests {
         }
     }
 
+    fn codex_request_with_route_matrix_controls() -> GatewayRequest {
+        let mut metadata = HashMap::new();
+        metadata.insert(
+            OPENAI_PARALLEL_TOOL_CALLS_METADATA_KEY.to_string(),
+            serde_json::Value::Bool(false),
+        );
+        metadata.insert(
+            OPENAI_RESPONSES_TOOL_CHOICE_METADATA_KEY.to_string(),
+            serde_json::json!({
+                "type": "function",
+                "function": { "name": "lookup" }
+            }),
+        );
+        metadata.insert(
+            OPENAI_RESPONSES_REASONING_EFFORT_METADATA_KEY.to_string(),
+            serde_json::Value::String("low".to_string()),
+        );
+        metadata.insert(
+            OPENAI_RESPONSES_REASONING_SUMMARY_METADATA_KEY.to_string(),
+            serde_json::Value::String("concise".to_string()),
+        );
+        metadata.insert(
+            OPENAI_RESPONSES_INCLUDE_METADATA_KEY.to_string(),
+            serde_json::json!(["reasoning.encrypted_content"]),
+        );
+        metadata.insert(
+            OPENAI_RESPONSES_TEXT_VERBOSITY_METADATA_KEY.to_string(),
+            serde_json::Value::String("low".to_string()),
+        );
+
+        GatewayRequest {
+            model: "gpt-4.1-mini".to_string(),
+            messages: vec![crate::models::Message {
+                role: "user".to_string(),
+                content: crate::models::MessageContent::Blocks(vec![
+                    ContentBlock::text("Describe this image".to_string(), None),
+                    ContentBlock::Known(KnownContentBlock::Image {
+                        source: crate::models::ImageSource {
+                            r#type: "url".to_string(),
+                            media_type: None,
+                            data: None,
+                            url: Some("https://example.com/image.png".to_string()),
+                        },
+                    }),
+                ]),
+            }],
+            max_output_tokens: 32,
+            reasoning: Some(crate::core::ReasoningConfig {
+                r#type: "enabled".to_string(),
+                budget_tokens: None,
+            }),
+            temperature: None,
+            top_p: None,
+            top_k: None,
+            stop_sequences: None,
+            stream: Some(false),
+            metadata: Some(metadata),
+            system: None,
+            tools: Some(vec![crate::models::Tool {
+                r#type: Some("function".to_string()),
+                name: Some("lookup".to_string()),
+                description: Some("Look something up".to_string()),
+                input_schema: Some(serde_json::json!({
+                    "type": "object",
+                    "properties": { "query": { "type": "string" } },
+                    "required": ["query"]
+                })),
+            }]),
+        }
+    }
+
     fn public_responses_continuation_request() -> GatewayRequest {
         let mut metadata = HashMap::new();
         metadata.insert(
@@ -4070,11 +4384,64 @@ mod tests {
             serialized["tool_choice"],
             serde_json::json!({
                 "type": "function",
-                "function": {
-                    "name": "lookup"
-                }
+                "name": "lookup"
             })
         );
+    }
+
+    #[test]
+    fn transform_to_responses_request_preserves_codex_route_matrix_controls() {
+        let provider = test_provider(OpenAITransport::OpenAI);
+        let request = codex_request_with_route_matrix_controls();
+
+        let serialized =
+            serde_json::to_value(provider.transform_to_responses_request(&request).unwrap())
+                .unwrap();
+
+        assert_eq!(serialized["stream"], serde_json::json!(true));
+        assert_eq!(serialized["parallel_tool_calls"], serde_json::json!(false));
+        assert_eq!(
+            serialized["tool_choice"],
+            serde_json::json!({
+                "type": "function",
+                "name": "lookup"
+            })
+        );
+        assert_eq!(
+            serialized["reasoning"],
+            serde_json::json!({
+                "effort": "low",
+                "summary": "concise"
+            })
+        );
+        assert_eq!(
+            serialized["include"],
+            serde_json::json!(["reasoning.encrypted_content"])
+        );
+        assert_eq!(
+            serialized["text"],
+            serde_json::json!({
+                "format": { "type": "text" },
+                "verbosity": "low"
+            })
+        );
+        assert_eq!(
+            serialized["input"][0]["content"][0],
+            serde_json::json!({
+                "type": "input_text",
+                "text": "Describe this image"
+            })
+        );
+        assert_eq!(
+            serialized["input"][0]["content"][1],
+            serde_json::json!({
+                "type": "input_image",
+                "image_url": "https://example.com/image.png"
+            })
+        );
+        let tools = serialized["tools"].as_array().expect("tools array");
+        assert_eq!(tools.len(), 1);
+        assert_eq!(tools[0]["function"]["name"], serde_json::json!("lookup"));
     }
 
     #[test]

--- a/crates/gateway/src/providers/openai.rs
+++ b/crates/gateway/src/providers/openai.rs
@@ -13,7 +13,9 @@ use regex::Regex;
 use reqwest::Client;
 use secrecy::ExposeSecret;
 use serde::{Deserialize, Serialize};
-use std::collections::{HashMap, HashSet};
+use std::collections::{BTreeMap, HashMap, HashSet};
+
+use crate::providers::streaming::{parse_sse_events, SseEvent, SseStream};
 
 const OPENAI_PARALLEL_TOOL_CALLS_METADATA_KEY: &str = "parallel_tool_calls";
 const OPENAI_PUBLIC_RESPONSES_METADATA_KEY: &str = "openai_public_responses";
@@ -513,6 +515,834 @@ pub(crate) struct OpenAIProviderConfig {
     pub custom_headers: Vec<(String, String)>,
     pub oauth_provider: Option<String>,
     pub token_store: Option<TokenStore>,
+}
+
+#[derive(Debug, Clone)]
+enum CodexSemanticItem {
+    Message {
+        text: String,
+    },
+    FunctionCall {
+        call_id: String,
+        name: String,
+        arguments: String,
+    },
+}
+
+#[derive(Debug, Default)]
+struct CodexSemanticAssemblyState {
+    response_id: Option<String>,
+    response_status: Option<String>,
+    usage: Option<GatewayUsage>,
+    open_items: HashMap<usize, CodexSemanticItem>,
+    finalized_items: BTreeMap<usize, CodexSemanticItem>,
+    saw_completed: bool,
+}
+
+#[derive(Debug, Default)]
+struct CodexSemanticStreamState {
+    response_id: Option<String>,
+    response_status: Option<String>,
+    usage: Option<GatewayUsage>,
+    message_started: bool,
+    saw_completed: bool,
+    text_block_started: HashSet<usize>,
+    tool_block_started: HashSet<usize>,
+    open_items: HashMap<usize, CodexSemanticItem>,
+}
+
+fn codex_transport_drift(message: impl Into<String>) -> ProviderError {
+    ProviderError::ApiError {
+        status: 502,
+        message: message.into(),
+    }
+}
+
+fn codex_semantic_output_index(json: &serde_json::Value) -> Result<usize, ProviderError> {
+    json.get("output_index")
+        .or_else(|| json.get("index"))
+        .and_then(|value| value.as_u64())
+        .map(|value| value as usize)
+        .ok_or_else(|| codex_transport_drift("Codex semantic event missing output index"))
+}
+
+fn codex_semantic_item_text(item: &serde_json::Value) -> String {
+    item.get("content")
+        .and_then(|value| value.as_array())
+        .into_iter()
+        .flat_map(|parts| parts.iter())
+        .filter(|part| part.get("type").and_then(|value| value.as_str()) == Some("output_text"))
+        .filter_map(|part| part.get("text").and_then(|value| value.as_str()))
+        .collect::<Vec<_>>()
+        .join("")
+}
+
+fn codex_semantic_item_function_call(item: &serde_json::Value) -> Option<(String, String, String)> {
+    let call_id = item.get("call_id").and_then(|value| value.as_str())?;
+    let name = item.get("name").and_then(|value| value.as_str())?;
+    let arguments = item
+        .get("arguments")
+        .and_then(|value| value.as_str())
+        .unwrap_or_default();
+    Some((call_id.to_string(), name.to_string(), arguments.to_string()))
+}
+
+fn codex_semantic_usage(response: &serde_json::Value) -> GatewayUsage {
+    let usage = response.get("usage");
+    let input_tokens = usage
+        .and_then(|value| value.get("input_tokens"))
+        .and_then(|value| value.as_u64())
+        .unwrap_or(0) as u32;
+    let output_tokens = usage
+        .and_then(|value| value.get("output_tokens"))
+        .and_then(|value| value.as_u64())
+        .unwrap_or(0) as u32;
+
+    GatewayUsage {
+        input_tokens,
+        output_tokens,
+        cache_creation_input_tokens: None,
+        cache_read_input_tokens: None,
+    }
+}
+
+fn codex_semantic_item_from_value(
+    item: &serde_json::Value,
+) -> Result<Option<CodexSemanticItem>, ProviderError> {
+    let Some(item_type) = item.get("type").and_then(|value| value.as_str()) else {
+        return Ok(None);
+    };
+
+    match item_type {
+        "message" => Ok(Some(CodexSemanticItem::Message {
+            text: codex_semantic_item_text(item),
+        })),
+        "function_call" => {
+            let Some((call_id, name, arguments)) = codex_semantic_item_function_call(item) else {
+                return Err(codex_transport_drift(
+                    "Codex semantic function_call item missing call_id, name, or arguments",
+                ));
+            };
+
+            Ok(Some(CodexSemanticItem::FunctionCall {
+                call_id,
+                name,
+                arguments,
+            }))
+        }
+        "reasoning" => Ok(None),
+        _ => Ok(None),
+    }
+}
+
+fn codex_semantic_item_to_content_block(
+    item: &CodexSemanticItem,
+) -> Result<Option<ContentBlock>, ProviderError> {
+    match item {
+        CodexSemanticItem::Message { text } => Ok(Some(ContentBlock::text(text.clone(), None))),
+        CodexSemanticItem::FunctionCall {
+            call_id,
+            name,
+            arguments,
+        } => {
+            let input = if arguments.trim().is_empty() {
+                serde_json::json!({})
+            } else {
+                serde_json::from_str(arguments).map_err(|_| {
+                    codex_transport_drift(
+                        "Codex semantic function_call arguments were not valid JSON",
+                    )
+                })?
+            };
+
+            Ok(Some(ContentBlock::tool_use(
+                call_id.clone(),
+                name.clone(),
+                input,
+            )))
+        }
+    }
+}
+
+impl CodexSemanticAssemblyState {
+    fn upsert_open_item(
+        &mut self,
+        output_index: usize,
+        item: Option<CodexSemanticItem>,
+    ) -> Result<(), ProviderError> {
+        if let Some(item) = item {
+            self.open_items.insert(output_index, item);
+        }
+        Ok(())
+    }
+
+    fn set_response_metadata(&mut self, response: &serde_json::Value) {
+        self.response_id = response
+            .get("id")
+            .and_then(|value| value.as_str())
+            .map(|value| value.to_string())
+            .or_else(|| self.response_id.take());
+        self.response_status = response
+            .get("status")
+            .and_then(|value| value.as_str())
+            .map(|value| value.to_string());
+        self.usage = Some(codex_semantic_usage(response));
+    }
+
+    fn finalize_output_index(
+        &mut self,
+        output_index: usize,
+        item_value: Option<&serde_json::Value>,
+    ) -> Result<(), ProviderError> {
+        if let Some(item) = self.open_items.remove(&output_index) {
+            self.finalized_items.insert(output_index, item);
+            return Ok(());
+        }
+
+        if let Some(item_value) = item_value {
+            if let Some(item) = codex_semantic_item_from_value(item_value)? {
+                self.finalized_items.insert(output_index, item);
+            }
+        }
+
+        Ok(())
+    }
+
+    fn finalize_pending_items(&mut self) -> Result<(), ProviderError> {
+        let pending_indexes = self.open_items.keys().copied().collect::<Vec<_>>();
+        for output_index in pending_indexes {
+            self.finalize_output_index(output_index, None)?;
+        }
+        Ok(())
+    }
+
+    fn consume_event(&mut self, event: &SseEvent) -> Result<(), ProviderError> {
+        let Some(name) = event.event.as_deref() else {
+            return Ok(());
+        };
+
+        let json: serde_json::Value = serde_json::from_str(&event.data).map_err(|_| {
+            codex_transport_drift(format!("Malformed Codex semantic SSE event: {name}"))
+        })?;
+
+        match name {
+            "response.output_item.added" => {
+                let output_index = codex_semantic_output_index(&json)?;
+                if let Some(item) = json.get("item") {
+                    if let Some(item) = codex_semantic_item_from_value(item)? {
+                        self.upsert_open_item(output_index, Some(item))?;
+                    }
+                }
+            }
+            "response.content_part.added" => {
+                let output_index = codex_semantic_output_index(&json)?;
+                if let Some(part) = json.get("part") {
+                    if part.get("type").and_then(|value| value.as_str()) == Some("output_text") {
+                        let text = part
+                            .get("text")
+                            .and_then(|value| value.as_str())
+                            .unwrap_or_default();
+                        match self.open_items.get_mut(&output_index) {
+                            Some(CodexSemanticItem::Message { text: current }) => {
+                                current.push_str(text);
+                            }
+                            Some(CodexSemanticItem::FunctionCall { .. }) => {
+                                return Err(codex_transport_drift(
+                                    "Codex semantic text arrived on a function_call item",
+                                ));
+                            }
+                            None => {
+                                self.open_items.insert(
+                                    output_index,
+                                    CodexSemanticItem::Message {
+                                        text: text.to_string(),
+                                    },
+                                );
+                            }
+                        }
+                    }
+                }
+            }
+            "response.output_text.delta" => {
+                let output_index = codex_semantic_output_index(&json)?;
+                let delta = json
+                    .get("delta")
+                    .and_then(|value| value.as_str())
+                    .unwrap_or_default();
+                match self.open_items.get_mut(&output_index) {
+                    Some(CodexSemanticItem::Message { text }) => text.push_str(delta),
+                    Some(CodexSemanticItem::FunctionCall { .. }) => {
+                        return Err(codex_transport_drift(
+                            "Codex semantic output_text.delta arrived on a function_call item",
+                        ));
+                    }
+                    None => {
+                        self.open_items.insert(
+                            output_index,
+                            CodexSemanticItem::Message {
+                                text: delta.to_string(),
+                            },
+                        );
+                    }
+                }
+            }
+            "response.output_text.done" => {
+                let output_index = codex_semantic_output_index(&json)?;
+                let text = json
+                    .get("text")
+                    .and_then(|value| value.as_str())
+                    .unwrap_or_default();
+                match self.open_items.get_mut(&output_index) {
+                    Some(CodexSemanticItem::Message { text: current }) => {
+                        if !text.is_empty() {
+                            *current = text.to_string();
+                        }
+                    }
+                    Some(CodexSemanticItem::FunctionCall { .. }) => {
+                        return Err(codex_transport_drift(
+                            "Codex semantic output_text.done arrived on a function_call item",
+                        ));
+                    }
+                    None => {
+                        self.open_items.insert(
+                            output_index,
+                            CodexSemanticItem::Message {
+                                text: text.to_string(),
+                            },
+                        );
+                    }
+                }
+            }
+            "response.function_call_arguments.delta" => {
+                let output_index = codex_semantic_output_index(&json)?;
+                let delta = json
+                    .get("delta")
+                    .and_then(|value| value.as_str())
+                    .unwrap_or_default();
+                match self.open_items.get_mut(&output_index) {
+                    Some(CodexSemanticItem::FunctionCall { arguments, .. }) => {
+                        arguments.push_str(delta);
+                    }
+                    Some(CodexSemanticItem::Message { .. }) => {
+                        return Err(codex_transport_drift(
+                            "Codex semantic function_call_arguments.delta arrived on a message item",
+                        ));
+                    }
+                    None => {
+                        return Err(codex_transport_drift(
+                            "Codex semantic function_call_arguments.delta arrived before the matching function_call item",
+                        ));
+                    }
+                }
+            }
+            "response.function_call_arguments.done" => {
+                let output_index = codex_semantic_output_index(&json)?;
+                let arguments = json
+                    .get("arguments")
+                    .and_then(|value| value.as_str())
+                    .unwrap_or_default();
+                match self.open_items.get_mut(&output_index) {
+                    Some(CodexSemanticItem::FunctionCall {
+                        arguments: current, ..
+                    }) => {
+                        if !arguments.is_empty() {
+                            *current = arguments.to_string();
+                        }
+                    }
+                    Some(CodexSemanticItem::Message { .. }) => {
+                        return Err(codex_transport_drift(
+                            "Codex semantic function_call_arguments.done arrived on a message item",
+                        ));
+                    }
+                    None => {
+                        return Err(codex_transport_drift(
+                            "Codex semantic function_call_arguments.done arrived before the matching function_call item",
+                        ));
+                    }
+                }
+            }
+            "response.output_item.done" => {
+                let output_index = codex_semantic_output_index(&json)?;
+                self.finalize_output_index(output_index, json.get("item"))?;
+            }
+            "response.completed" => {
+                if let Some(response) = json.get("response") {
+                    self.set_response_metadata(response);
+                    self.saw_completed = true;
+                    self.finalize_pending_items()?;
+                }
+            }
+            _ => {}
+        }
+
+        Ok(())
+    }
+
+    fn into_gateway_response(self, model: String) -> Result<GatewayResponse, ProviderError> {
+        if !self.saw_completed {
+            return Err(codex_transport_drift(
+                "Codex semantic SSE stream ended without response.completed",
+            ));
+        }
+
+        let mut content = Vec::new();
+        for item in self.finalized_items.values() {
+            if let Some(block) = codex_semantic_item_to_content_block(item)? {
+                content.push(block);
+            }
+        }
+
+        let usage = self.usage.unwrap_or(GatewayUsage {
+            input_tokens: 0,
+            output_tokens: 0,
+            cache_creation_input_tokens: None,
+            cache_read_input_tokens: None,
+        });
+
+        Ok(GatewayResponse {
+            id: self
+                .response_id
+                .unwrap_or_else(|| "codex-semantic-response".to_string()),
+            r#type: "message".to_string(),
+            role: "assistant".to_string(),
+            content,
+            model,
+            stop_reason: Some(match self.response_status.as_deref() {
+                Some("incomplete") => "max_tokens".to_string(),
+                _ => "end_turn".to_string(),
+            }),
+            stop_sequence: None,
+            usage,
+        })
+    }
+}
+
+impl CodexSemanticStreamState {
+    fn ensure_message_start(&mut self, output: &mut String, model: &str) {
+        if self.message_started {
+            return;
+        }
+
+        self.message_started = true;
+        let response_id = self
+            .response_id
+            .clone()
+            .unwrap_or_else(|| format!("codex_{}", uuid::Uuid::new_v4()));
+        let message_start = serde_json::json!({
+            "type": "message_start",
+            "message": {
+                "id": response_id,
+                "type": "message",
+                "role": "assistant",
+                "content": [],
+                "model": model,
+                "stop_reason": null,
+                "stop_sequence": null,
+                "usage": {
+                    "input_tokens": 0,
+                    "output_tokens": 0
+                }
+            }
+        });
+        OpenAIProvider::push_sse_event(output, "message_start", message_start);
+    }
+
+    fn ensure_text_block(&mut self, output: &mut String, output_index: usize) {
+        if self.text_block_started.contains(&output_index) {
+            return;
+        }
+
+        self.text_block_started.insert(output_index);
+        OpenAIProvider::push_sse_event(
+            output,
+            "content_block_start",
+            serde_json::json!({
+                "type": "content_block_start",
+                "index": output_index,
+                "content_block": {
+                    "type": "text",
+                    "text": ""
+                }
+            }),
+        );
+    }
+
+    fn ensure_tool_block(
+        &mut self,
+        output: &mut String,
+        output_index: usize,
+        call_id: &str,
+        name: &str,
+    ) {
+        if self.tool_block_started.contains(&output_index) {
+            return;
+        }
+
+        self.tool_block_started.insert(output_index);
+        OpenAIProvider::push_sse_event(
+            output,
+            "content_block_start",
+            serde_json::json!({
+                "type": "content_block_start",
+                "index": output_index,
+                "content_block": {
+                    "type": "tool_use",
+                    "id": call_id,
+                    "name": name,
+                    "input": {}
+                }
+            }),
+        );
+    }
+
+    fn close_text_block(&mut self, output: &mut String, output_index: usize) {
+        if self.text_block_started.remove(&output_index) {
+            OpenAIProvider::push_sse_event(
+                output,
+                "content_block_stop",
+                serde_json::json!({
+                    "type": "content_block_stop",
+                    "index": output_index
+                }),
+            );
+        }
+    }
+
+    fn close_tool_block(&mut self, output: &mut String, output_index: usize) {
+        if self.tool_block_started.remove(&output_index) {
+            OpenAIProvider::push_sse_event(
+                output,
+                "content_block_stop",
+                serde_json::json!({
+                    "type": "content_block_stop",
+                    "index": output_index
+                }),
+            );
+        }
+    }
+
+    fn emit_message_stop(&mut self, output: &mut String) {
+        let usage = self.usage.clone().unwrap_or(GatewayUsage {
+            input_tokens: 0,
+            output_tokens: 0,
+            cache_creation_input_tokens: None,
+            cache_read_input_tokens: None,
+        });
+        let message_delta = serde_json::json!({
+            "type": "message_delta",
+            "delta": {
+                "stop_reason": match self.response_status.as_deref() {
+                    Some("incomplete") => "max_tokens",
+                    _ => "end_turn",
+                },
+                "stop_sequence": null
+            },
+            "usage": {
+                "input_tokens": usage.input_tokens,
+                "output_tokens": usage.output_tokens
+            }
+        });
+        OpenAIProvider::push_sse_event(output, "message_delta", message_delta);
+        OpenAIProvider::push_sse_event(
+            output,
+            "message_stop",
+            serde_json::json!({
+                "type": "message_stop"
+            }),
+        );
+    }
+
+    fn consume_event(&mut self, event: &SseEvent, model: &str) -> Result<String, ProviderError> {
+        let mut output = String::new();
+        let Some(name) = event.event.as_deref() else {
+            return Ok(output);
+        };
+
+        let json: serde_json::Value = serde_json::from_str(&event.data).map_err(|_| {
+            codex_transport_drift(format!("Malformed Codex semantic SSE event: {name}"))
+        })?;
+
+        match name {
+            "response.output_item.added" => {
+                let output_index = codex_semantic_output_index(&json)?;
+                if let Some(item) = json.get("item") {
+                    if let Some(item) = codex_semantic_item_from_value(item)? {
+                        self.open_items.insert(output_index, item.clone());
+                        match item {
+                            CodexSemanticItem::Message { text } => {
+                                self.ensure_message_start(&mut output, model);
+                                if !text.is_empty() {
+                                    self.ensure_text_block(&mut output, output_index);
+                                    OpenAIProvider::push_sse_event(
+                                        &mut output,
+                                        "content_block_delta",
+                                        serde_json::json!({
+                                            "type": "content_block_delta",
+                                            "index": output_index,
+                                            "delta": {
+                                                "type": "text_delta",
+                                                "text": text
+                                            }
+                                        }),
+                                    );
+                                }
+                            }
+                            CodexSemanticItem::FunctionCall {
+                                call_id,
+                                name,
+                                arguments,
+                            } => {
+                                self.ensure_message_start(&mut output, model);
+                                self.ensure_tool_block(&mut output, output_index, &call_id, &name);
+                                if !arguments.is_empty() {
+                                    OpenAIProvider::push_sse_event(
+                                        &mut output,
+                                        "content_block_delta",
+                                        serde_json::json!({
+                                            "type": "content_block_delta",
+                                            "index": output_index,
+                                            "delta": {
+                                                "type": "input_json_delta",
+                                                "partial_json": arguments
+                                            }
+                                        }),
+                                    );
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+            "response.content_part.added" => {
+                let output_index = codex_semantic_output_index(&json)?;
+                let Some(part) = json.get("part") else {
+                    return Ok(output);
+                };
+                if part.get("type").and_then(|value| value.as_str()) == Some("output_text") {
+                    let text = part
+                        .get("text")
+                        .and_then(|value| value.as_str())
+                        .unwrap_or_default();
+                    self.ensure_message_start(&mut output, model);
+                    self.ensure_text_block(&mut output, output_index);
+                    if !text.is_empty() {
+                        OpenAIProvider::push_sse_event(
+                            &mut output,
+                            "content_block_delta",
+                            serde_json::json!({
+                                "type": "content_block_delta",
+                                "index": output_index,
+                                "delta": {
+                                    "type": "text_delta",
+                                    "text": text
+                                }
+                            }),
+                        );
+                    }
+                }
+            }
+            "response.output_text.delta" => {
+                let output_index = codex_semantic_output_index(&json)?;
+                let delta = json
+                    .get("delta")
+                    .and_then(|value| value.as_str())
+                    .unwrap_or_default();
+                self.ensure_message_start(&mut output, model);
+                self.ensure_text_block(&mut output, output_index);
+                if let Some(CodexSemanticItem::Message { text }) =
+                    self.open_items.get_mut(&output_index)
+                {
+                    text.push_str(delta);
+                } else if !self.open_items.contains_key(&output_index) {
+                    self.open_items.insert(
+                        output_index,
+                        CodexSemanticItem::Message {
+                            text: delta.to_string(),
+                        },
+                    );
+                }
+                if !delta.is_empty() {
+                    OpenAIProvider::push_sse_event(
+                        &mut output,
+                        "content_block_delta",
+                        serde_json::json!({
+                            "type": "content_block_delta",
+                            "index": output_index,
+                            "delta": {
+                                "type": "text_delta",
+                                "text": delta
+                            }
+                        }),
+                    );
+                }
+            }
+            "response.output_text.done" => {
+                let output_index = codex_semantic_output_index(&json)?;
+                self.close_text_block(&mut output, output_index);
+                if let Some(CodexSemanticItem::Message { text }) =
+                    self.open_items.get_mut(&output_index)
+                {
+                    let done_text = json
+                        .get("text")
+                        .and_then(|value| value.as_str())
+                        .unwrap_or_default();
+                    if !done_text.is_empty() {
+                        *text = done_text.to_string();
+                    }
+                }
+            }
+            "response.function_call_arguments.delta" => {
+                let output_index = codex_semantic_output_index(&json)?;
+                let delta = json
+                    .get("delta")
+                    .and_then(|value| value.as_str())
+                    .unwrap_or_default();
+                let Some(CodexSemanticItem::FunctionCall {
+                    call_id,
+                    name,
+                    arguments,
+                }) = self.open_items.get_mut(&output_index)
+                else {
+                    return Err(codex_transport_drift(
+                        "Codex semantic function_call_arguments.delta arrived before the matching function_call item",
+                    ));
+                };
+                let call_id = call_id.clone();
+                let name = name.clone();
+                arguments.push_str(delta);
+                self.ensure_message_start(&mut output, model);
+                self.ensure_tool_block(&mut output, output_index, &call_id, &name);
+                if !delta.is_empty() {
+                    OpenAIProvider::push_sse_event(
+                        &mut output,
+                        "content_block_delta",
+                        serde_json::json!({
+                            "type": "content_block_delta",
+                            "index": output_index,
+                            "delta": {
+                                "type": "input_json_delta",
+                                "partial_json": delta
+                            }
+                        }),
+                    );
+                }
+            }
+            "response.function_call_arguments.done" => {
+                let output_index = codex_semantic_output_index(&json)?;
+                let Some(CodexSemanticItem::FunctionCall {
+                    call_id,
+                    name,
+                    arguments,
+                }) = self.open_items.get_mut(&output_index)
+                else {
+                    return Err(codex_transport_drift(
+                        "Codex semantic function_call_arguments.done arrived before the matching function_call item",
+                    ));
+                };
+                let done_arguments = json
+                    .get("arguments")
+                    .and_then(|value| value.as_str())
+                    .unwrap_or_default();
+                if !done_arguments.is_empty() {
+                    *arguments = done_arguments.to_string();
+                }
+                let call_id = call_id.clone();
+                let name = name.clone();
+                self.ensure_message_start(&mut output, model);
+                self.ensure_tool_block(&mut output, output_index, &call_id, &name);
+            }
+            "response.output_item.done" => {
+                let output_index = codex_semantic_output_index(&json)?;
+                if let Some(item) = self.open_items.remove(&output_index) {
+                    match item {
+                        CodexSemanticItem::Message { .. } => {
+                            self.ensure_message_start(&mut output, model);
+                            self.close_text_block(&mut output, output_index);
+                        }
+                        CodexSemanticItem::FunctionCall { .. } => {
+                            self.ensure_message_start(&mut output, model);
+                            self.close_tool_block(&mut output, output_index);
+                        }
+                    }
+                } else if let Some(item_value) = json.get("item") {
+                    if let Some(item) = codex_semantic_item_from_value(item_value)? {
+                        self.ensure_message_start(&mut output, model);
+                        match item {
+                            CodexSemanticItem::Message { .. } => {
+                                self.close_text_block(&mut output, output_index);
+                            }
+                            CodexSemanticItem::FunctionCall {
+                                call_id,
+                                name,
+                                arguments,
+                            } => {
+                                self.ensure_tool_block(&mut output, output_index, &call_id, &name);
+                                if !arguments.is_empty() {
+                                    OpenAIProvider::push_sse_event(
+                                        &mut output,
+                                        "content_block_delta",
+                                        serde_json::json!({
+                                            "type": "content_block_delta",
+                                            "index": output_index,
+                                            "delta": {
+                                                "type": "input_json_delta",
+                                                "partial_json": arguments
+                                            }
+                                        }),
+                                    );
+                                }
+                                self.close_tool_block(&mut output, output_index);
+                            }
+                        }
+                    }
+                }
+            }
+            "response.completed" => {
+                let Some(response) = json.get("response") else {
+                    return Err(codex_transport_drift(
+                        "Codex semantic response.completed event missing response envelope",
+                    ));
+                };
+                self.ensure_message_start(&mut output, model);
+                self.response_id = response
+                    .get("id")
+                    .and_then(|value| value.as_str())
+                    .map(|value| value.to_string())
+                    .or_else(|| self.response_id.take());
+                self.response_status = response
+                    .get("status")
+                    .and_then(|value| value.as_str())
+                    .map(|value| value.to_string());
+                self.usage = Some(codex_semantic_usage(response));
+                self.saw_completed = true;
+
+                let pending_text = self.text_block_started.iter().copied().collect::<Vec<_>>();
+                for output_index in pending_text {
+                    self.close_text_block(&mut output, output_index);
+                }
+
+                let pending_tools = self.tool_block_started.iter().copied().collect::<Vec<_>>();
+                for output_index in pending_tools {
+                    self.close_tool_block(&mut output, output_index);
+                }
+
+                self.emit_message_stop(&mut output);
+            }
+            _ => {}
+        }
+
+        Ok(output)
+    }
+
+    fn finalize(&self, _model: &str) -> Result<String, ProviderError> {
+        if !self.saw_completed {
+            return Err(codex_transport_drift(
+                "Codex semantic SSE stream ended without response.completed",
+            ));
+        }
+
+        Ok(String::new())
+    }
 }
 
 impl OpenAIProvider {
@@ -1978,6 +2808,17 @@ impl super::GatewayProvider for OpenAIProvider {
             let response_text = response.text().await?;
             tracing::debug!("Responses API response body: {}", response_text);
 
+            if self.is_oauth() {
+                let events = parse_sse_events(&response_text);
+                let mut state = CodexSemanticAssemblyState::default();
+
+                for event in &events {
+                    state.consume_event(event)?;
+                }
+
+                return state.into_gateway_response(request.model.clone());
+            }
+
             // Parse SSE (Server-Sent Events) format
             // Format: event: xxx\ndata: {...}\n\n
             // This extracts both reasoning (converted to thinking) and message blocks
@@ -2193,193 +3034,255 @@ impl super::GatewayProvider for OpenAIProvider {
             });
         }
 
-        // Transform OpenAI SSE format to Anthropic SSE format
-        use crate::providers::streaming::SseStream;
         use futures::stream::StreamExt;
         use std::sync::{Arc, Mutex};
 
-        let message_id = format!("msg_{}", uuid::Uuid::new_v4());
-
-        // Streaming State Management
-        // ===========================
-        // Using Arc<Mutex<StreamTransformState>> to track state across async chunks.
-        // The state tracks: message_started, text_block_open, tool_blocks, stream_ended
-        let state = Arc::new(Mutex::new(StreamTransformState::default()));
-        let state_for_cleanup = state.clone();
-
-        // Convert response bytes stream to SSE events
-        let sse_stream = SseStream::new(response.bytes_stream());
-
-        // Capture provider/model names for logging
-        let provider_name = self.name.clone();
         let model_name = request.model.clone();
+        let stream_model_name = model_name.clone();
+        let cleanup_model_name = model_name.clone();
 
-        // Transform OpenAI SSE events to Anthropic format
-        let transformed_stream = sse_stream
-            .then(move |result| {
-                let message_id = message_id.clone();
-                let state = state.clone();
-                let provider_name = provider_name.clone();
+        let finalized_stream: std::pin::Pin<
+            Box<dyn futures::stream::Stream<Item = Result<Bytes, ProviderError>> + Send>,
+        > = if self.is_oauth() {
+            let state = Arc::new(Mutex::new(CodexSemanticStreamState::default()));
+            let state_for_cleanup = state.clone();
+            let provider_name = self.name.clone();
 
-                async move {
-                    match result {
-                        Ok(sse_event) => {
-                            // If stream already ended, don't process any more chunks
-                            if state.lock().unwrap().stream_ended {
-                                tracing::debug!("⏹️ Stream already ended, skipping chunk");
-                                return Ok(Bytes::new());
-                            }
+            let transformed_stream = SseStream::new(response.bytes_stream())
+                .then(move |result| {
+                    let state = state.clone();
+                    let model_name = stream_model_name.clone();
+                    let provider_name = provider_name.clone();
 
-                            tracing::debug!("📦 Received SSE chunk: {}", sse_event.data);
-
-                            // Skip empty data
-                            if sse_event.data.trim().is_empty() {
-                                tracing::debug!("⏭️ Skipping empty SSE event");
-                                return Ok(Bytes::new());
-                            }
-
-                            if sse_event.data.trim() == "[DONE]" {
-                                tracing::debug!("✅ Stream finished with [DONE]");
-                                return Ok(Bytes::new());
-                            }
-
-                            // Check for error response first (some providers return HTTP 200 with error in body)
-                            if let Ok(error_response) =
-                                serde_json::from_str::<OpenAIStreamError>(&sse_event.data)
-                            {
-                                let status = error_response.status_code.unwrap_or(500);
-                                let error_type =
-                                    error_response.error.r#type.as_deref().unwrap_or("unknown");
-                                tracing::error!(
-                                    "❌ {} upstream error ({}): {} [type={}]",
-                                    provider_name,
-                                    status,
-                                    error_response.error.message,
-                                    error_type
-                                );
-                                return Err(ProviderError::ApiError {
-                                    status,
-                                    message: format!(
-                                        "{}: {}",
-                                        provider_name, error_response.error.message
-                                    ),
-                                });
-                            }
-
-                            // Parse OpenAI chunk
-                            match serde_json::from_str::<OpenAIStreamChunk>(&sse_event.data) {
-                                Ok(chunk) => {
-                                    tracing::debug!(
-                                        "✨ Transforming chunk with {} choices",
-                                        chunk.choices.len()
-                                    );
-
-                                    // Transform to Anthropic format (raw SSE bytes)
-                                    let sse_output = Self::transform_openai_chunk_to_anthropic_sse(
-                                        &chunk,
-                                        &message_id,
-                                        &mut state.lock().unwrap(),
-                                    );
-
-                                    if !sse_output.is_empty() {
-                                        tracing::debug!("SSE: {} bytes", sse_output.len());
-                                    } else {
-                                        tracing::debug!("SSE: empty output (will be filtered)");
+                    async move {
+                        match result {
+                            Ok(sse_event) => {
+                                let mut state = state.lock().unwrap();
+                                match state.consume_event(&sse_event, &model_name) {
+                                    Ok(output) => Ok(Bytes::from(output)),
+                                    Err(err) => {
+                                        tracing::error!(
+                                            "❌ {} failed to assemble Codex semantic SSE: {}",
+                                            provider_name,
+                                            err
+                                        );
+                                        Err(err)
                                     }
-
-                                    // Return as raw bytes (already SSE-formatted)
-                                    Ok(Bytes::from(sse_output))
-                                }
-                                Err(e) => {
-                                    tracing::warn!(
-                                        "❌ {} failed to parse chunk: {} - Data: {}",
-                                        provider_name,
-                                        e,
-                                        sse_event.data
-                                    );
-                                    Ok(Bytes::new())
                                 }
                             }
-                        }
-                        Err(e) => {
-                            tracing::error!("💥 Stream error: {}", e);
-                            Err(ProviderError::HttpError(e))
+                            Err(e) => {
+                                tracing::error!("💥 Stream error: {}", e);
+                                Err(ProviderError::HttpError(e))
+                            }
                         }
                     }
-                }
-            })
-            .try_filter(|bytes| futures::future::ready(!bytes.is_empty()));
+                })
+                .try_filter(|bytes| futures::future::ready(!bytes.is_empty()));
 
-        // Add stream finalization to ensure proper termination
-        // Some providers close streams without sending finish_reason
-        let finalized_stream = transformed_stream
-            .chain(futures::stream::once(async move {
-                let state = state_for_cleanup.lock().unwrap();
-                tracing::debug!(
-                    "🏁 Stream finalization: message_started={}, stream_ended={}",
-                    state.message_started,
-                    state.stream_ended
-                );
-
-                // Only send end events if stream didn't end properly
-                if state.message_started && !state.stream_ended {
-                    tracing::warn!("⚠️ Stream ended without finish_reason - sending end events");
-
-                    let mut output = String::new();
-
-                    // Close text block if open
-                    if state.text_block_open {
-                        let block_stop = serde_json::json!({
-                            "type": "content_block_stop",
-                            "index": state.text_block_index
-                        });
-                        output.push_str(&format!(
-                            "event: content_block_stop\ndata: {}\n\n",
-                            block_stop
-                        ));
-                    }
-
-                    // Close all tool blocks
-                    for block_index in state.tool_blocks.values() {
-                        let block_stop = serde_json::json!({
-                            "type": "content_block_stop",
-                            "index": block_index
-                        });
-                        output.push_str(&format!(
-                            "event: content_block_stop\ndata: {}\n\n",
-                            block_stop
-                        ));
-                    }
-
-                    // Send message_delta with end_turn (we don't know the real stop_reason)
-                    let message_delta = serde_json::json!({
-                        "type": "message_delta",
-                        "delta": {
-                            "stop_reason": "end_turn",
-                            "stop_sequence": null
-                        },
-                        "usage": {
-                            "output_tokens": 0
+            Box::pin(
+                transformed_stream
+                    .chain(futures::stream::once(async move {
+                        let state = state_for_cleanup.lock().unwrap();
+                        match state.finalize(&cleanup_model_name) {
+                            Ok(output) if !output.is_empty() => Ok(Bytes::from(output)),
+                            Ok(_) => Ok(Bytes::new()),
+                            Err(err) => Err(err),
                         }
-                    });
-                    output.push_str(&format!(
-                        "event: message_delta\ndata: {}\n\n",
-                        message_delta
-                    ));
+                    }))
+                    .try_filter(|bytes| futures::future::ready(!bytes.is_empty())),
+            )
+        } else {
+            // Transform OpenAI SSE format to Anthropic SSE format
+            let message_id = format!("msg_{}", uuid::Uuid::new_v4());
 
-                    // Send message_stop
-                    let message_stop = serde_json::json!({
-                        "type": "message_stop"
-                    });
-                    output.push_str(&format!("event: message_stop\ndata: {}\n\n", message_stop));
+            // Streaming State Management
+            // ===========================
+            // Using Arc<Mutex<StreamTransformState>> to track state across async chunks.
+            // The state tracks: message_started, text_block_open, tool_blocks, stream_ended
+            let state = Arc::new(Mutex::new(StreamTransformState::default()));
+            let state_for_cleanup = state.clone();
 
-                    Ok(Bytes::from(output))
-                } else {
-                    tracing::debug!("🏁 Stream properly ended, no finalization needed");
-                    Ok(Bytes::new())
-                }
-            }))
-            .try_filter(|bytes| futures::future::ready(!bytes.is_empty()));
+            // Convert response bytes stream to SSE events
+            let sse_stream = SseStream::new(response.bytes_stream());
+
+            // Capture provider/model names for logging
+            let provider_name = self.name.clone();
+
+            // Transform OpenAI SSE events to Anthropic format
+            let transformed_stream = sse_stream
+                .then(move |result| {
+                    let message_id = message_id.clone();
+                    let state = state.clone();
+                    let provider_name = provider_name.clone();
+
+                    async move {
+                        match result {
+                            Ok(sse_event) => {
+                                // If stream already ended, don't process any more chunks
+                                if state.lock().unwrap().stream_ended {
+                                    tracing::debug!("⏹️ Stream already ended, skipping chunk");
+                                    return Ok(Bytes::new());
+                                }
+
+                                tracing::debug!("📦 Received SSE chunk: {}", sse_event.data);
+
+                                // Skip empty data
+                                if sse_event.data.trim().is_empty() {
+                                    tracing::debug!("⏭️ Skipping empty SSE event");
+                                    return Ok(Bytes::new());
+                                }
+
+                                if sse_event.data.trim() == "[DONE]" {
+                                    tracing::debug!("✅ Stream finished with [DONE]");
+                                    return Ok(Bytes::new());
+                                }
+
+                                // Check for error response first (some providers return HTTP 200 with error in body)
+                                if let Ok(error_response) =
+                                    serde_json::from_str::<OpenAIStreamError>(&sse_event.data)
+                                {
+                                    let status = error_response.status_code.unwrap_or(500);
+                                    let error_type =
+                                        error_response.error.r#type.as_deref().unwrap_or("unknown");
+                                    tracing::error!(
+                                        "❌ {} upstream error ({}): {} [type={}]",
+                                        provider_name,
+                                        status,
+                                        error_response.error.message,
+                                        error_type
+                                    );
+                                    return Err(ProviderError::ApiError {
+                                        status,
+                                        message: format!(
+                                            "{}: {}",
+                                            provider_name, error_response.error.message
+                                        ),
+                                    });
+                                }
+
+                                // Parse OpenAI chunk
+                                match serde_json::from_str::<OpenAIStreamChunk>(&sse_event.data) {
+                                    Ok(chunk) => {
+                                        tracing::debug!(
+                                            "✨ Transforming chunk with {} choices",
+                                            chunk.choices.len()
+                                        );
+
+                                        // Transform to Anthropic format (raw SSE bytes)
+                                        let sse_output =
+                                            Self::transform_openai_chunk_to_anthropic_sse(
+                                                &chunk,
+                                                &message_id,
+                                                &mut state.lock().unwrap(),
+                                            );
+
+                                        if !sse_output.is_empty() {
+                                            tracing::debug!("SSE: {} bytes", sse_output.len());
+                                        } else {
+                                            tracing::debug!("SSE: empty output (will be filtered)");
+                                        }
+
+                                        // Return as raw bytes (already SSE-formatted)
+                                        Ok(Bytes::from(sse_output))
+                                    }
+                                    Err(e) => {
+                                        tracing::warn!(
+                                            "❌ {} failed to parse chunk: {} - Data: {}",
+                                            provider_name,
+                                            e,
+                                            sse_event.data
+                                        );
+                                        Ok(Bytes::new())
+                                    }
+                                }
+                            }
+                            Err(e) => {
+                                tracing::error!("💥 Stream error: {}", e);
+                                Err(ProviderError::HttpError(e))
+                            }
+                        }
+                    }
+                })
+                .try_filter(|bytes| futures::future::ready(!bytes.is_empty()));
+
+            // Add stream finalization to ensure proper termination
+            // Some providers close streams without sending finish_reason
+            Box::pin(
+                transformed_stream
+                    .chain(futures::stream::once(async move {
+                        let state = state_for_cleanup.lock().unwrap();
+                        tracing::debug!(
+                            "🏁 Stream finalization: message_started={}, stream_ended={}",
+                            state.message_started,
+                            state.stream_ended
+                        );
+
+                        // Only send end events if stream didn't end properly
+                        if state.message_started && !state.stream_ended {
+                            tracing::warn!(
+                                "⚠️ Stream ended without finish_reason - sending end events"
+                            );
+
+                            let mut output = String::new();
+
+                            // Close text block if open
+                            if state.text_block_open {
+                                let block_stop = serde_json::json!({
+                                    "type": "content_block_stop",
+                                    "index": state.text_block_index
+                                });
+                                output.push_str(&format!(
+                                    "event: content_block_stop\ndata: {}\n\n",
+                                    block_stop
+                                ));
+                            }
+
+                            // Close all tool blocks
+                            for block_index in state.tool_blocks.values() {
+                                let block_stop = serde_json::json!({
+                                    "type": "content_block_stop",
+                                    "index": block_index
+                                });
+                                output.push_str(&format!(
+                                    "event: content_block_stop\ndata: {}\n\n",
+                                    block_stop
+                                ));
+                            }
+
+                            // Send message_delta with end_turn (we don't know the real stop_reason)
+                            let message_delta = serde_json::json!({
+                                "type": "message_delta",
+                                "delta": {
+                                    "stop_reason": "end_turn",
+                                    "stop_sequence": null
+                                },
+                                "usage": {
+                                    "output_tokens": 0
+                                }
+                            });
+                            output.push_str(&format!(
+                                "event: message_delta\ndata: {}\n\n",
+                                message_delta
+                            ));
+
+                            // Send message_stop
+                            let message_stop = serde_json::json!({
+                                "type": "message_stop"
+                            });
+                            output.push_str(&format!(
+                                "event: message_stop\ndata: {}\n\n",
+                                message_stop
+                            ));
+
+                            Ok(Bytes::from(output))
+                        } else {
+                            tracing::debug!("🏁 Stream properly ended, no finalization needed");
+                            Ok(Bytes::new())
+                        }
+                    }))
+                    .try_filter(|bytes| futures::future::ready(!bytes.is_empty())),
+            )
+        };
 
         // Wrap with logging stream to capture token stats
         use crate::providers::streaming::LoggingSseStream;
@@ -3860,5 +4763,149 @@ mod tests {
             stop_reason_from_sse_outputs(&outputs).as_deref(),
             Some("tool_use")
         );
+    }
+
+    #[test]
+    fn codex_semantic_sync_assembles_text_and_tools_from_event_family() {
+        let sse_text = [
+            r#"event: response.output_item.added
+data: {"type":"response.output_item.added","output_index":0,"item":{"type":"message","role":"assistant","content":[{"type":"output_text","text":"Visible"}]}}
+
+"#,
+            r#"event: response.content_part.added
+data: {"type":"response.content_part.added","output_index":0,"content_index":0,"part":{"type":"output_text","text":" answer"}}
+
+"#,
+            r#"event: response.output_text.delta
+data: {"type":"response.output_text.delta","output_index":0,"content_index":0,"delta":"!"}
+
+"#,
+            r#"event: response.output_text.done
+data: {"type":"response.output_text.done","output_index":0,"content_index":0,"text":"Visible answer!"}
+
+"#,
+            r#"event: response.output_item.done
+data: {"type":"response.output_item.done","output_index":0,"item":{"type":"message","role":"assistant","content":[{"type":"output_text","text":"Visible answer!"}]}}
+
+"#,
+            r#"event: response.output_item.added
+data: {"type":"response.output_item.added","output_index":1,"item":{"type":"function_call","call_id":"call_1","name":"lookup","arguments":"{}"}}
+
+"#,
+            r#"event: response.function_call_arguments.delta
+data: {"type":"response.function_call_arguments.delta","output_index":1,"call_id":"call_1","delta":"{\"path\":\"README.md\"}"}
+
+"#,
+            r#"event: response.function_call_arguments.done
+data: {"type":"response.function_call_arguments.done","output_index":1,"call_id":"call_1","arguments":"{\"path\":\"README.md\"}"}
+
+"#,
+            r#"event: response.output_item.done
+data: {"type":"response.output_item.done","output_index":1,"item":{"type":"function_call","call_id":"call_1","name":"lookup","arguments":"{\"path\":\"README.md\"}"}}
+
+"#,
+            r#"event: response.completed
+data: {"type":"response.completed","response":{"id":"resp_codex","status":"completed","output":[],"usage":{"input_tokens":7,"output_tokens":2}}}
+
+"#,
+        ]
+        .join("");
+
+        let events = parse_sse_events(&sse_text);
+        let mut state = CodexSemanticAssemblyState::default();
+
+        for event in &events {
+            state.consume_event(event).unwrap();
+        }
+
+        let response = state
+            .into_gateway_response("gateway-default".to_string())
+            .unwrap();
+
+        assert_eq!(response.id, "resp_codex");
+        assert_eq!(response.model, "gateway-default");
+        assert_eq!(response.stop_reason.as_deref(), Some("end_turn"));
+        assert_eq!(response.usage.input_tokens, 7);
+        assert_eq!(response.usage.output_tokens, 2);
+        assert_eq!(response.content.len(), 2);
+        assert!(matches!(
+            &response.content[0],
+            ContentBlock::Known(KnownContentBlock::Text { text, .. }) if text == "Visible answer!"
+        ));
+        assert!(matches!(
+            &response.content[1],
+            ContentBlock::Known(KnownContentBlock::ToolUse { id, name, input, .. })
+            if id == "call_1" && name == "lookup" && input == &serde_json::json!({"path":"README.md"})
+        ));
+    }
+
+    #[test]
+    fn codex_semantic_sync_requires_terminal_completed_event() {
+        let sse_text = r#"event: response.output_text.delta
+data: {"type":"response.output_text.delta","output_index":0,"content_index":0,"delta":"Visible"}
+
+"#;
+        let events = parse_sse_events(sse_text);
+        let mut state = CodexSemanticAssemblyState::default();
+
+        for event in &events {
+            state.consume_event(event).unwrap();
+        }
+
+        let error = state
+            .into_gateway_response("gateway-default".to_string())
+            .unwrap_err();
+        assert!(matches!(error, ProviderError::ApiError { status: 502, .. }));
+    }
+
+    #[test]
+    fn codex_semantic_stream_emits_anthropic_sse_and_hides_reasoning() {
+        let sse_text = [
+            r#"event: response.output_item.added
+data: {"type":"response.output_item.added","output_index":0,"item":{"type":"reasoning","content":[{"type":"output_text","text":"secret reasoning"}]}}
+
+"#,
+            r#"event: response.output_item.added
+data: {"type":"response.output_item.added","output_index":1,"item":{"type":"message","role":"assistant","content":[{"type":"output_text","text":"Visible"}]}}
+
+"#,
+            r#"event: response.output_text.delta
+data: {"type":"response.output_text.delta","output_index":1,"content_index":0,"delta":" answer"}
+
+"#,
+            r#"event: response.output_item.added
+data: {"type":"response.output_item.added","output_index":2,"item":{"type":"function_call","call_id":"call_2","name":"lookup","arguments":"{}"}}
+
+"#,
+            r#"event: response.function_call_arguments.delta
+data: {"type":"response.function_call_arguments.delta","output_index":2,"call_id":"call_2","delta":"{\"path\":\"README.md\"}"}
+
+"#,
+            r#"event: response.completed
+data: {"type":"response.completed","response":{"id":"resp_stream","status":"completed","output":[],"usage":{"input_tokens":4,"output_tokens":2}}}
+
+"#,
+        ]
+        .join("");
+
+        let events = parse_sse_events(&sse_text);
+        let mut state = CodexSemanticStreamState::default();
+        let mut output = String::new();
+
+        for event in &events {
+            output.push_str(&state.consume_event(event, "gateway-default").unwrap());
+        }
+
+        assert!(!output.contains("secret reasoning"));
+        let parsed_events = parse_sse_events(&output);
+        let names = parsed_events
+            .iter()
+            .filter_map(|event| event.event.as_deref())
+            .collect::<Vec<_>>();
+
+        assert!(names.contains(&"message_start"));
+        assert!(names.contains(&"content_block_delta"));
+        assert!(names.contains(&"message_delta"));
+        assert!(names.contains(&"message_stop"));
     }
 }

--- a/crates/gateway/src/providers/openai.rs
+++ b/crates/gateway/src/providers/openai.rs
@@ -3078,15 +3078,15 @@ impl super::GatewayProvider for OpenAIProvider {
         // - OAuth: Always use /codex/responses for all models
         // - API Key: Only use /responses for models containing "codex"
         let use_responses_api = self.should_use_responses_api(&request);
-        let codex_auth_context = if self.is_oauth() && use_responses_api {
-            Some(self.resolve_codex_auth_context()?)
-        } else {
-            None
-        };
 
         if use_responses_api {
             // Use /v1/responses endpoint for Codex models
             let responses_request = self.transform_to_responses_request(&request)?;
+            let codex_auth_context = if self.is_oauth() {
+                Some(self.resolve_codex_auth_context()?)
+            } else {
+                None
+            };
 
             // OAuth (ChatGPT Codex) uses /codex/responses, API Key uses /responses
             let endpoint = if self.is_oauth() {
@@ -3298,11 +3298,6 @@ impl super::GatewayProvider for OpenAIProvider {
 
         // Check if this is a Codex model
         let use_responses_api = self.should_use_responses_api(&request);
-        let codex_auth_context = if self.is_oauth() && use_responses_api {
-            Some(self.resolve_codex_auth_context()?)
-        } else {
-            None
-        };
 
         let (url, request_body) = if use_responses_api {
             // Use /v1/responses endpoint for Codex models
@@ -3325,6 +3320,12 @@ impl super::GatewayProvider for OpenAIProvider {
             let body =
                 serde_json::to_value(&openai_request).map_err(ProviderError::SerializationError)?;
             (self.endpoint_url("/chat/completions"), body)
+        };
+
+        let codex_auth_context = if self.is_oauth() && use_responses_api {
+            Some(self.resolve_codex_auth_context()?)
+        } else {
+            None
         };
 
         let auth_value = match codex_auth_context.as_ref() {
@@ -3652,6 +3653,7 @@ mod tests {
     use crate::auth::codex_auth_context::{CodexAccountIdSource, CodexAuthMode};
     use crate::auth::CodexAuthSource;
     use crate::models::SystemPrompt;
+    use crate::providers::GatewayProvider;
     use base64::engine::general_purpose::URL_SAFE_NO_PAD;
     use secrecy::SecretString;
     use serde::Deserialize;
@@ -4888,6 +4890,59 @@ mod tests {
                 }
                 other => panic!("expected config error for {field}, got {other:?}"),
             }
+        }
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn send_message_validates_codex_route_before_resolving_integrated_auth() {
+        let _guard = ENV_LOCK.lock().unwrap();
+        let provider = test_oauth_provider();
+        let original_account_id = env::var_os(
+            crate::auth::codex_auth_context::SUBSTRATE_LLM_BACKEND_AUTH_CLI_CODEX_ACCOUNT_ID,
+        );
+        let original_access_token = env::var_os(
+            crate::auth::codex_auth_context::SUBSTRATE_LLM_BACKEND_AUTH_CLI_CODEX_ACCESS_TOKEN,
+        );
+
+        env::remove_var(
+            crate::auth::codex_auth_context::SUBSTRATE_LLM_BACKEND_AUTH_CLI_CODEX_ACCOUNT_ID,
+        );
+        env::remove_var(
+            crate::auth::codex_auth_context::SUBSTRATE_LLM_BACKEND_AUTH_CLI_CODEX_ACCESS_TOKEN,
+        );
+
+        let mut request = gateway_request_with_parallel_tool_calls(None);
+        request.metadata = Some(HashMap::from([(
+            OPENAI_RESPONSES_EXPLICIT_MAX_OUTPUT_TOKENS_METADATA_KEY.to_string(),
+            serde_json::json!(64),
+        )]));
+
+        let result = provider.send_message(request).await;
+
+        match original_account_id {
+            Some(value) => env::set_var(
+                crate::auth::codex_auth_context::SUBSTRATE_LLM_BACKEND_AUTH_CLI_CODEX_ACCOUNT_ID,
+                value,
+            ),
+            None => env::remove_var(
+                crate::auth::codex_auth_context::SUBSTRATE_LLM_BACKEND_AUTH_CLI_CODEX_ACCOUNT_ID,
+            ),
+        }
+        match original_access_token {
+            Some(value) => env::set_var(
+                crate::auth::codex_auth_context::SUBSTRATE_LLM_BACKEND_AUTH_CLI_CODEX_ACCESS_TOKEN,
+                value,
+            ),
+            None => env::remove_var(
+                crate::auth::codex_auth_context::SUBSTRATE_LLM_BACKEND_AUTH_CLI_CODEX_ACCESS_TOKEN,
+            ),
+        }
+
+        match result {
+            Err(ProviderError::ConfigError(message)) => {
+                assert!(message.contains("max_output_tokens is not supported on the Codex route"));
+            }
+            other => panic!("expected route validation config error, got {other:?}"),
         }
     }
 

--- a/crates/gateway/src/providers/openai.rs
+++ b/crates/gateway/src/providers/openai.rs
@@ -1,5 +1,7 @@
 use super::{error::ProviderError, OpenAITransport};
-use crate::auth::{CodexAuthState, OAuthClient, OAuthConfig, ResolvedCodexAuthContext, TokenStore};
+use crate::auth::{
+    CodexAuthSource, OAuthClient, OAuthConfig, ResolvedCodexAuthContext, TokenStore,
+};
 use crate::core::{GatewayRequest, GatewayResponse, GatewayStreamResponse, GatewayUsage};
 use crate::models::{
     ContentBlock, CountTokensRequest, CountTokensResponse, ImageSource, KnownContentBlock,
@@ -71,7 +73,7 @@ struct OpenAIRequest {
 
 /// OpenAI Responses API request format (for Codex models)
 #[derive(Debug, Serialize)]
-struct OpenAIResponsesRequest {
+pub(crate) struct OpenAIResponsesRequest {
     model: String,
     input: OpenAIResponsesInput,
     /// System instructions for the model (required for ChatGPT Codex)
@@ -86,6 +88,18 @@ struct OpenAIResponsesRequest {
     parallel_tool_calls: Option<bool>,
     #[serde(skip_serializing_if = "Option::is_none")]
     max_output_tokens: Option<u32>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    metadata: Option<serde_json::Value>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    truncation: Option<serde_json::Value>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    previous_response_id: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    user: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    stream_options: Option<serde_json::Value>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    service_tier: Option<serde_json::Value>,
     #[serde(skip_serializing_if = "Option::is_none")]
     reasoning: Option<serde_json::Value>,
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -524,6 +538,8 @@ pub struct OpenAIProvider {
     oauth_provider: Option<String>,
     /// Token store for OAuth authentication
     token_store: Option<TokenStore>,
+    /// Explicit Codex auth source selected at bootstrap for OAuth-backed Codex routes
+    codex_auth_source: Option<CodexAuthSource>,
 }
 
 pub(crate) struct OpenAIProviderConfig {
@@ -534,6 +550,7 @@ pub(crate) struct OpenAIProviderConfig {
     pub custom_headers: Vec<(String, String)>,
     pub oauth_provider: Option<String>,
     pub token_store: Option<TokenStore>,
+    pub codex_auth_source: Option<CodexAuthSource>,
 }
 
 #[derive(Debug, Clone)]
@@ -1193,13 +1210,12 @@ impl CodexSemanticStreamState {
                     self.open_items.get_mut(&output_index)
                 {
                     text.push_str(delta);
-                } else if !self.open_items.contains_key(&output_index) {
-                    self.open_items.insert(
-                        output_index,
+                } else {
+                    self.open_items.entry(output_index).or_insert_with(|| {
                         CodexSemanticItem::Message {
                             text: delta.to_string(),
-                        },
-                    );
+                        }
+                    });
                 }
                 if !delta.is_empty() {
                     OpenAIProvider::push_sse_event(
@@ -1508,34 +1524,13 @@ impl OpenAIProvider {
     }
 
     fn resolve_codex_auth_context(&self) -> Result<ResolvedCodexAuthContext, ProviderError> {
-        if let Some(handoff) =
-            crate::auth::codex_auth_context::CodexIntegratedAuthHandoff::from_env().map_err(
-                |e| {
-                    ProviderError::AuthError(format!(
-                        "Failed to resolve Codex integrated handoff: {}",
-                        e
-                    ))
-                },
-            )?
-        {
-            return crate::auth::codex_auth_context::CodexAuthSelection::Integrated(handoff)
-                .resolve()
-                .map_err(|e| {
-                    ProviderError::AuthError(format!("Failed to resolve Codex auth context: {}", e))
-                });
-        }
-
-        let local_auth_path = CodexAuthState::default_path().map_err(|e| {
-            ProviderError::AuthError(format!("Failed to resolve Codex auth path: {}", e))
+        let source = self.codex_auth_source.as_ref().ok_or_else(|| {
+            ProviderError::AuthError(
+                "Codex auth source is not configured for the selected OAuth route".to_string(),
+            )
         })?;
 
-        crate::auth::codex_auth_context::CodexAuthSelection::Standalone(
-            CodexAuthState::load(local_auth_path).map_err(|e| {
-                ProviderError::AuthError(format!("Failed to load Codex auth state: {}", e))
-            })?,
-        )
-        .resolve()
-        .map_err(|e| {
+        source.resolve().map_err(|e| {
             ProviderError::AuthError(format!("Failed to resolve Codex auth context: {}", e))
         })
     }
@@ -1897,7 +1892,7 @@ impl OpenAIProvider {
     }
 
     /// Transform Anthropic request to OpenAI Responses API format
-    fn transform_to_responses_request(
+    pub(crate) fn transform_to_responses_request(
         &self,
         request: &GatewayRequest,
     ) -> Result<OpenAIResponsesRequest, ProviderError> {
@@ -2245,6 +2240,44 @@ impl OpenAIProvider {
                     .then_some(serde_json::json!({ "format": { "type": "text" } }))
             });
 
+        let input_metadata = request
+            .metadata
+            .as_ref()
+            .and_then(|metadata| metadata.get(OPENAI_RESPONSES_INPUT_METADATA_METADATA_KEY))
+            .cloned();
+
+        let truncation = request
+            .metadata
+            .as_ref()
+            .and_then(|metadata| metadata.get(OPENAI_RESPONSES_TRUNCATION_METADATA_KEY))
+            .cloned();
+
+        let previous_response_id = request
+            .metadata
+            .as_ref()
+            .and_then(|metadata| metadata.get(OPENAI_RESPONSES_PREVIOUS_RESPONSE_ID_METADATA_KEY))
+            .and_then(|value| value.as_str())
+            .map(ToString::to_string);
+
+        let user = request
+            .metadata
+            .as_ref()
+            .and_then(|metadata| metadata.get(OPENAI_RESPONSES_USER_METADATA_KEY))
+            .and_then(|value| value.as_str())
+            .map(ToString::to_string);
+
+        let stream_options = request
+            .metadata
+            .as_ref()
+            .and_then(|metadata| metadata.get(OPENAI_RESPONSES_STREAM_OPTIONS_METADATA_KEY))
+            .cloned();
+
+        let service_tier = request
+            .metadata
+            .as_ref()
+            .and_then(|metadata| metadata.get(OPENAI_RESPONSES_SERVICE_TIER_METADATA_KEY))
+            .cloned();
+
         Ok(OpenAIResponsesRequest {
             model: request.model.clone(),
             input: OpenAIResponsesInput::Items(items),
@@ -2257,6 +2290,12 @@ impl OpenAIProvider {
                 .and_then(|metadata| metadata.get(OPENAI_PARALLEL_TOOL_CALLS_METADATA_KEY))
                 .and_then(|value| value.as_bool()),
             max_output_tokens: (!self.is_oauth()).then_some(request.max_output_tokens),
+            metadata: (!self.is_oauth()).then_some(input_metadata).flatten(),
+            truncation: (!self.is_oauth()).then_some(truncation).flatten(),
+            previous_response_id: (!self.is_oauth()).then_some(previous_response_id).flatten(),
+            user: (!self.is_oauth()).then_some(user).flatten(),
+            stream_options: (!self.is_oauth()).then_some(stream_options).flatten(),
+            service_tier: (!self.is_oauth()).then_some(service_tier).flatten(),
             reasoning,
             include,
             text,
@@ -2281,6 +2320,7 @@ impl OpenAIProvider {
             custom_headers: config.custom_headers,
             oauth_provider: config.oauth_provider,
             token_store: config.token_store,
+            codex_auth_source: config.codex_auth_source,
         }
     }
 
@@ -2338,7 +2378,7 @@ impl OpenAIProvider {
 
     /// Check if using OAuth authentication
     fn is_oauth(&self) -> bool {
-        self.oauth_provider.is_some() && self.token_store.is_some()
+        self.oauth_provider.is_some()
     }
 
     /// Extract ChatGPT account ID from JWT access token
@@ -3602,8 +3642,8 @@ impl super::GatewayProvider for OpenAIProvider {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::auth::codex_auth_context::CodexAuthSelection;
-    use crate::auth::codex_auth_context::{CodexAccountIdSource, CodexIntegratedAuthHandoff};
+    use crate::auth::codex_auth_context::{CodexAccountIdSource, CodexAuthMode};
+    use crate::auth::CodexAuthSource;
     use crate::models::SystemPrompt;
     use base64::engine::general_purpose::URL_SAFE_NO_PAD;
     use secrecy::SecretString;
@@ -3710,6 +3750,7 @@ mod tests {
             custom_headers: Vec::new(),
             oauth_provider: None,
             token_store: None,
+            codex_auth_source: None,
         }
     }
 
@@ -3730,6 +3771,7 @@ mod tests {
             custom_headers: Vec::new(),
             oauth_provider: Some("test-oauth-provider".to_string()),
             token_store: Some(token_store),
+            codex_auth_source: Some(CodexAuthSource::Integrated),
         }
     }
 
@@ -3745,19 +3787,32 @@ mod tests {
         format!("{header}.{payload}.signature")
     }
 
-    fn codex_resolved_context(account_id: &str) -> ResolvedCodexAuthContext {
-        CodexAuthSelection::Integrated(CodexIntegratedAuthHandoff::new(
-            Some(account_id.to_string()),
-            SecretString::new(codex_access_token(account_id)),
-        ))
-        .resolve()
-        .unwrap()
-    }
-
-    fn codex_resolved_context_from_selection(
-        selection: CodexAuthSelection,
+    fn codex_resolved_context(
+        mode: CodexAuthMode,
+        explicit_account_id: Option<&str>,
+        access_token: SecretString,
     ) -> Result<ResolvedCodexAuthContext, anyhow::Error> {
-        selection.resolve()
+        if let Some(account_id) = explicit_account_id
+            .map(str::trim)
+            .filter(|value| !value.is_empty())
+        {
+            return Ok(ResolvedCodexAuthContext {
+                mode,
+                account_id: account_id.to_string(),
+                account_id_source: CodexAccountIdSource::Explicit,
+                access_token,
+            });
+        }
+
+        let account_id = OpenAIProvider::extract_account_id(access_token.expose_secret())
+            .ok_or_else(|| anyhow::anyhow!("Codex auth context could not resolve account_id"))?;
+
+        Ok(ResolvedCodexAuthContext {
+            mode,
+            account_id,
+            account_id_source: CodexAccountIdSource::JwtFallback,
+            access_token,
+        })
     }
 
     #[test]
@@ -4042,6 +4097,61 @@ mod tests {
         }
     }
 
+    fn public_responses_request_with_passthrough_controls() -> GatewayRequest {
+        let mut metadata = HashMap::new();
+        metadata.insert(
+            OPENAI_PUBLIC_RESPONSES_METADATA_KEY.to_string(),
+            serde_json::Value::Bool(true),
+        );
+        metadata.insert(
+            OPENAI_RESPONSES_INPUT_METADATA_METADATA_KEY.to_string(),
+            serde_json::json!({
+                "client": "sdk",
+                "request_id": "req_123"
+            }),
+        );
+        metadata.insert(
+            OPENAI_RESPONSES_TRUNCATION_METADATA_KEY.to_string(),
+            serde_json::json!("auto"),
+        );
+        metadata.insert(
+            OPENAI_RESPONSES_PREVIOUS_RESPONSE_ID_METADATA_KEY.to_string(),
+            serde_json::Value::String("resp_prev_123".to_string()),
+        );
+        metadata.insert(
+            OPENAI_RESPONSES_USER_METADATA_KEY.to_string(),
+            serde_json::Value::String("user_123".to_string()),
+        );
+        metadata.insert(
+            OPENAI_RESPONSES_STREAM_OPTIONS_METADATA_KEY.to_string(),
+            serde_json::json!({
+                "include_obfuscation": true
+            }),
+        );
+        metadata.insert(
+            OPENAI_RESPONSES_SERVICE_TIER_METADATA_KEY.to_string(),
+            serde_json::json!("priority"),
+        );
+
+        GatewayRequest {
+            model: "gpt-4.1-mini".to_string(),
+            messages: vec![crate::models::Message {
+                role: "user".to_string(),
+                content: crate::models::MessageContent::Text("hello".to_string()),
+            }],
+            max_output_tokens: 32,
+            reasoning: None,
+            temperature: None,
+            top_p: None,
+            top_k: None,
+            stop_sequences: None,
+            stream: Some(false),
+            metadata: Some(metadata),
+            system: None,
+            tools: None,
+        }
+    }
+
     fn orphaned_public_responses_continuation_request() -> GatewayRequest {
         let mut metadata = HashMap::new();
         metadata.insert(
@@ -4088,6 +4198,7 @@ mod tests {
             custom_headers: Vec::new(),
             oauth_provider: None,
             token_store: None,
+            codex_auth_source: None,
         }
     }
 
@@ -4141,6 +4252,7 @@ mod tests {
             custom_headers: Vec::new(),
             oauth_provider: Some("test-oauth-provider".to_string()),
             token_store: Some(token_store),
+            codex_auth_source: Some(CodexAuthSource::Integrated),
         };
 
         assert_eq!(
@@ -4186,6 +4298,7 @@ mod tests {
                 custom_headers: Vec::new(),
                 oauth_provider: None,
                 token_store: None,
+                codex_auth_source: None,
             },
         );
 
@@ -4626,9 +4739,99 @@ mod tests {
     }
 
     #[test]
+    fn transform_to_responses_request_preserves_public_passthrough_controls() {
+        let provider = test_provider(OpenAITransport::OpenAI);
+        let request = public_responses_request_with_passthrough_controls();
+
+        let serialized =
+            serde_json::to_value(provider.transform_to_responses_request(&request).unwrap())
+                .unwrap();
+
+        assert_eq!(
+            serialized["metadata"],
+            serde_json::json!({
+                "client": "sdk",
+                "request_id": "req_123"
+            })
+        );
+        assert_eq!(serialized["truncation"], serde_json::json!("auto"));
+        assert_eq!(
+            serialized["previous_response_id"],
+            serde_json::json!("resp_prev_123")
+        );
+        assert_eq!(serialized["user"], serde_json::json!("user_123"));
+        assert_eq!(
+            serialized["stream_options"],
+            serde_json::json!({
+                "include_obfuscation": true
+            })
+        );
+        assert_eq!(serialized["service_tier"], serde_json::json!("priority"));
+    }
+
+    #[test]
+    fn transform_to_responses_request_rejects_public_passthrough_controls_on_codex_route() {
+        let provider = test_oauth_provider();
+
+        for (field, metadata_key, metadata_value) in [
+            (
+                "metadata",
+                OPENAI_RESPONSES_INPUT_METADATA_METADATA_KEY,
+                serde_json::json!({"client": "sdk"}),
+            ),
+            (
+                "truncation",
+                OPENAI_RESPONSES_TRUNCATION_METADATA_KEY,
+                serde_json::json!("auto"),
+            ),
+            (
+                "previous_response_id",
+                OPENAI_RESPONSES_PREVIOUS_RESPONSE_ID_METADATA_KEY,
+                serde_json::json!("resp_prev_123"),
+            ),
+            (
+                "user",
+                OPENAI_RESPONSES_USER_METADATA_KEY,
+                serde_json::json!("user_123"),
+            ),
+            (
+                "stream_options",
+                OPENAI_RESPONSES_STREAM_OPTIONS_METADATA_KEY,
+                serde_json::json!({"include_obfuscation": true}),
+            ),
+            (
+                "service_tier",
+                OPENAI_RESPONSES_SERVICE_TIER_METADATA_KEY,
+                serde_json::json!("priority"),
+            ),
+        ] {
+            let mut request = gateway_request_with_parallel_tool_calls(None);
+            request.metadata = Some(HashMap::from([(metadata_key.to_string(), metadata_value)]));
+
+            let err = provider
+                .transform_to_responses_request(&request)
+                .unwrap_err();
+            match err {
+                ProviderError::ConfigError(message) => {
+                    assert!(
+                        message.contains(field),
+                        "expected reject message to mention {field}, got {message}"
+                    );
+                }
+                other => panic!("expected config error for {field}, got {other:?}"),
+            }
+        }
+    }
+
+    #[test]
     fn codex_oauth_request_builder_emits_only_the_minimal_header_contract() {
         let provider = test_oauth_provider();
-        let auth_context = codex_resolved_context("acct_123");
+        let auth_context = codex_resolved_context(
+            CodexAuthMode::Integrated,
+            Some("acct_123"),
+            SecretString::new(codex_access_token("acct_123")),
+        )
+        .unwrap();
         let expected_auth = format!("Bearer {}", auth_context.access_token.expose_secret());
         let (auth_header_name, auth_header_value) =
             provider.auth_header_parts(auth_context.access_token.expose_secret(), true);
@@ -4681,11 +4884,12 @@ mod tests {
     #[test]
     fn codex_oauth_request_builder_prefers_explicit_account_id_over_jwt_fallback() {
         let provider = test_oauth_provider();
-        let selection = CodexAuthSelection::Integrated(CodexIntegratedAuthHandoff::new(
-            Some("acct_explicit".to_string()),
+        let auth_context = codex_resolved_context(
+            CodexAuthMode::Integrated,
+            Some("acct_explicit"),
             SecretString::new(codex_access_token("acct_jwt")),
-        ));
-        let auth_context = codex_resolved_context_from_selection(selection).unwrap();
+        )
+        .unwrap();
         assert_eq!(auth_context.account_id, "acct_explicit");
         assert_eq!(
             auth_context.account_id_source,
@@ -4726,11 +4930,12 @@ mod tests {
     #[test]
     fn codex_oauth_request_builder_uses_jwt_fallback_only_when_explicit_account_id_is_absent() {
         let provider = test_oauth_provider();
-        let selection = CodexAuthSelection::Standalone(CodexAuthState::new(
+        let auth_context = codex_resolved_context(
+            CodexAuthMode::Standalone,
             None,
             SecretString::new(codex_access_token("acct_jwt")),
-        ));
-        let auth_context = codex_resolved_context_from_selection(selection).unwrap();
+        )
+        .unwrap();
         assert_eq!(auth_context.account_id, "acct_jwt");
         assert_eq!(
             auth_context.account_id_source,
@@ -4770,12 +4975,12 @@ mod tests {
 
     #[test]
     fn codex_oauth_request_builder_fails_before_upstream_when_account_id_is_unresolvable() {
-        let selection = CodexAuthSelection::Standalone(CodexAuthState::new(
+        let err = codex_resolved_context(
+            CodexAuthMode::Standalone,
             None,
             SecretString::new("not-a-jwt".to_string()),
-        ));
-
-        let err = codex_resolved_context_from_selection(selection).unwrap_err();
+        )
+        .unwrap_err();
         assert!(
             err.to_string()
                 .contains("Codex auth context could not resolve account_id"),

--- a/crates/gateway/src/providers/openai.rs
+++ b/crates/gateway/src/providers/openai.rs
@@ -2067,7 +2067,8 @@ impl OpenAIProvider {
         }
 
         let mut items = Vec::new();
-        let mut synthesized_call_ids = HashSet::new();
+        let mut emitted_call_ids = HashSet::new();
+        let mut authoritative_provenance = HashMap::new();
 
         if let Some(ref system) = request.system {
             let mut content = system_prompt_to_responses_parts(system);
@@ -2104,12 +2105,15 @@ impl OpenAIProvider {
                                     &msg.role,
                                     &mut content_parts,
                                 );
-                                synthesized_call_ids.insert(id.clone());
+                                let arguments = serde_json::to_string(input)
+                                    .unwrap_or_else(|_| "{}".to_string());
+                                authoritative_provenance
+                                    .insert(id.clone(), (name.clone(), arguments.clone()));
+                                emitted_call_ids.insert(id.clone());
                                 items.push(OpenAIResponsesInputItem::FunctionCall {
                                     call_id: id.clone(),
                                     name: name.clone(),
-                                    arguments: serde_json::to_string(input)
-                                        .unwrap_or_else(|_| "{}".to_string()),
+                                    arguments,
                                 });
                             }
                             ContentBlock::Known(KnownContentBlock::ToolResult {
@@ -2123,11 +2127,20 @@ impl OpenAIProvider {
                                     &msg.role,
                                     &mut content_parts,
                                 );
-                                if synthesized_call_ids.insert(tool_use_id.clone()) {
+                                if !emitted_call_ids.contains(tool_use_id) {
+                                    let Some((name, arguments)) =
+                                        authoritative_provenance.get(tool_use_id).cloned()
+                                    else {
+                                        return Err(ProviderError::ConfigError(
+                                            "Responses continuation requires authoritative provenance for each function_call_output"
+                                                .to_string(),
+                                        ));
+                                    };
+                                    emitted_call_ids.insert(tool_use_id.clone());
                                     items.push(OpenAIResponsesInputItem::FunctionCall {
                                         call_id: tool_use_id.clone(),
-                                        name: "tool_call".to_string(),
-                                        arguments: "{}".to_string(),
+                                        name,
+                                        arguments,
                                     });
                                 }
                                 let output = if *is_error {
@@ -3991,6 +4004,18 @@ mod tests {
                     content: crate::models::MessageContent::Text("Need tool output.".to_string()),
                 },
                 crate::models::Message {
+                    role: "assistant".to_string(),
+                    content: crate::models::MessageContent::Blocks(vec![ContentBlock::Known(
+                        KnownContentBlock::ToolUse {
+                            id: "call_fixture_1".to_string(),
+                            name: "lookup".to_string(),
+                            input: serde_json::json!({
+                                "query": "x"
+                            }),
+                        },
+                    )]),
+                },
+                crate::models::Message {
                     role: "user".to_string(),
                     content: crate::models::MessageContent::Blocks(vec![ContentBlock::Known(
                         KnownContentBlock::ToolResult {
@@ -4004,6 +4029,41 @@ mod tests {
                     )]),
                 },
             ],
+            max_output_tokens: 32,
+            reasoning: None,
+            temperature: None,
+            top_p: None,
+            top_k: None,
+            stop_sequences: None,
+            stream: Some(false),
+            metadata: Some(metadata),
+            system: None,
+            tools: None,
+        }
+    }
+
+    fn orphaned_public_responses_continuation_request() -> GatewayRequest {
+        let mut metadata = HashMap::new();
+        metadata.insert(
+            OPENAI_PUBLIC_RESPONSES_METADATA_KEY.to_string(),
+            serde_json::Value::Bool(true),
+        );
+
+        GatewayRequest {
+            model: "gpt-4.1-mini".to_string(),
+            messages: vec![crate::models::Message {
+                role: "user".to_string(),
+                content: crate::models::MessageContent::Blocks(vec![ContentBlock::Known(
+                    KnownContentBlock::ToolResult {
+                        tool_use_id: "call_fixture_1".to_string(),
+                        content: crate::models::ToolResultContent::Text(
+                            "{\"ok\":true}".to_string(),
+                        ),
+                        is_error: false,
+                        cache_control: None,
+                    },
+                )]),
+            }],
             max_output_tokens: 32,
             reasoning: None,
             temperature: None,
@@ -4359,12 +4419,133 @@ mod tests {
         );
         assert_eq!(input[1]["type"], serde_json::json!("function_call"));
         assert_eq!(input[1]["call_id"], serde_json::json!("call_fixture_1"));
-        assert_eq!(input[1]["arguments"], serde_json::json!("{}"));
+        assert_eq!(input[1]["name"], serde_json::json!("lookup"));
+        assert_eq!(
+            input[1]["arguments"],
+            serde_json::json!("{\"query\":\"x\"}")
+        );
         assert_eq!(input[2]["type"], serde_json::json!("function_call_output"));
         assert_eq!(input[2]["call_id"], serde_json::json!("call_fixture_1"));
         assert_eq!(input[2]["output"], serde_json::json!("{\"ok\":true}"));
         assert!(serialized.get("instructions").is_none());
         assert!(serialized.get("store").is_none());
+    }
+
+    #[test]
+    fn transform_to_responses_request_rejects_orphaned_tool_results() {
+        let provider = test_provider(OpenAITransport::OpenAI);
+        let request = orphaned_public_responses_continuation_request();
+
+        let err = provider
+            .transform_to_responses_request(&request)
+            .unwrap_err();
+        match err {
+            ProviderError::ConfigError(message) => {
+                assert!(message.contains("authoritative provenance"));
+            }
+            other => panic!("expected config error, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn transform_to_responses_request_preserves_mixed_continuation_order() {
+        let provider = test_provider(OpenAITransport::OpenAI);
+        let mut metadata = HashMap::new();
+        metadata.insert(
+            OPENAI_PUBLIC_RESPONSES_METADATA_KEY.to_string(),
+            serde_json::Value::Bool(true),
+        );
+
+        let request = GatewayRequest {
+            model: "gpt-4.1-mini".to_string(),
+            messages: vec![
+                crate::models::Message {
+                    role: "assistant".to_string(),
+                    content: crate::models::MessageContent::Text("first".to_string()),
+                },
+                crate::models::Message {
+                    role: "assistant".to_string(),
+                    content: crate::models::MessageContent::Blocks(vec![ContentBlock::Known(
+                        KnownContentBlock::ToolUse {
+                            id: "call_1".to_string(),
+                            name: "lookup".to_string(),
+                            input: serde_json::json!({"query":"a"}),
+                        },
+                    )]),
+                },
+                crate::models::Message {
+                    role: "user".to_string(),
+                    content: crate::models::MessageContent::Blocks(vec![ContentBlock::Known(
+                        KnownContentBlock::ToolResult {
+                            tool_use_id: "call_1".to_string(),
+                            content: crate::models::ToolResultContent::Text(
+                                "{\"ok\":1}".to_string(),
+                            ),
+                            is_error: false,
+                            cache_control: None,
+                        },
+                    )]),
+                },
+                crate::models::Message {
+                    role: "assistant".to_string(),
+                    content: crate::models::MessageContent::Text("second".to_string()),
+                },
+                crate::models::Message {
+                    role: "assistant".to_string(),
+                    content: crate::models::MessageContent::Blocks(vec![ContentBlock::Known(
+                        KnownContentBlock::ToolUse {
+                            id: "call_2".to_string(),
+                            name: "lookup".to_string(),
+                            input: serde_json::json!({"query":"b"}),
+                        },
+                    )]),
+                },
+                crate::models::Message {
+                    role: "user".to_string(),
+                    content: crate::models::MessageContent::Blocks(vec![ContentBlock::Known(
+                        KnownContentBlock::ToolResult {
+                            tool_use_id: "call_2".to_string(),
+                            content: crate::models::ToolResultContent::Text(
+                                "{\"ok\":2}".to_string(),
+                            ),
+                            is_error: false,
+                            cache_control: None,
+                        },
+                    )]),
+                },
+            ],
+            max_output_tokens: 32,
+            reasoning: None,
+            temperature: None,
+            top_p: None,
+            top_k: None,
+            stop_sequences: None,
+            stream: Some(false),
+            metadata: Some(metadata),
+            system: None,
+            tools: None,
+        };
+
+        let serialized =
+            serde_json::to_value(provider.transform_to_responses_request(&request).unwrap())
+                .unwrap();
+        let input = serialized["input"]
+            .as_array()
+            .expect("responses input array");
+
+        assert_eq!(input.len(), 6);
+        assert_eq!(input[0]["type"], serde_json::json!("message"));
+        assert_eq!(input[0]["content"][0]["text"], serde_json::json!("first"));
+        assert_eq!(input[1]["type"], serde_json::json!("function_call"));
+        assert_eq!(input[1]["call_id"], serde_json::json!("call_1"));
+        assert_eq!(input[2]["type"], serde_json::json!("function_call_output"));
+        assert_eq!(input[2]["call_id"], serde_json::json!("call_1"));
+        assert_eq!(input[3]["type"], serde_json::json!("message"));
+        assert_eq!(input[3]["content"][0]["text"], serde_json::json!("second"));
+        assert_eq!(input[4]["type"], serde_json::json!("function_call"));
+        assert_eq!(input[4]["call_id"], serde_json::json!("call_2"));
+        assert_eq!(input[5]["type"], serde_json::json!("function_call_output"));
+        assert_eq!(input[5]["call_id"], serde_json::json!("call_2"));
     }
 
     #[test]

--- a/crates/gateway/src/providers/registry.rs
+++ b/crates/gateway/src/providers/registry.rs
@@ -3,7 +3,7 @@ use super::{
     error::ProviderError, AnthropicCompatibleProvider, GatewayProvider, OpenAIProvider,
     OpenAIProviderConfig, OpenAITransport, ProviderConfig,
 };
-use crate::auth::TokenStore;
+use crate::auth::{CodexAuthSource, CodexAuthState, TokenStore};
 use crate::cli::ModelConfig;
 use std::collections::HashMap;
 use std::sync::Arc;
@@ -13,6 +13,74 @@ const DEFAULT_OPENAI_BASE_URL: &str = "https://api.openai.com/v1";
 
 /// GitHub repository URL (used in HTTP-Referer headers)
 const REPO_URL: &str = "https://github.com/elidickinson/claude-code-mux";
+
+/// Runtime bootstrap carrier for the effective `llm.gateway.mode` posture.
+const SUBSTRATE_LLM_GATEWAY_MODE: &str = "SUBSTRATE_LLM_GATEWAY_MODE";
+const GATEWAY_MODE_IN_WORLD: &str = "in_world";
+const GATEWAY_MODE_HOST_ONLY: &str = "host_only";
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum GatewayBootstrapMode {
+    InWorld,
+    HostOnly,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+struct ProviderBootstrapContext {
+    gateway_mode: GatewayBootstrapMode,
+}
+
+impl ProviderBootstrapContext {
+    fn from_env() -> Result<Self, ProviderError> {
+        let gateway_mode = match std::env::var(SUBSTRATE_LLM_GATEWAY_MODE) {
+            Ok(value) => match value.trim() {
+                GATEWAY_MODE_IN_WORLD => GatewayBootstrapMode::InWorld,
+                GATEWAY_MODE_HOST_ONLY => GatewayBootstrapMode::HostOnly,
+                other => {
+                    return Err(ProviderError::ConfigError(format!(
+                        "Invalid {} value '{}'; expected '{}' or '{}'",
+                        SUBSTRATE_LLM_GATEWAY_MODE,
+                        other,
+                        GATEWAY_MODE_IN_WORLD,
+                        GATEWAY_MODE_HOST_ONLY
+                    )));
+                }
+            },
+            Err(std::env::VarError::NotPresent) => GatewayBootstrapMode::HostOnly,
+            Err(err) => {
+                return Err(ProviderError::ConfigError(format!(
+                    "Failed to read {}: {}",
+                    SUBSTRATE_LLM_GATEWAY_MODE, err
+                )));
+            }
+        };
+
+        Ok(Self { gateway_mode })
+    }
+}
+
+fn codex_auth_source_for_openai_oauth(
+    config: &ProviderConfig,
+    bootstrap: ProviderBootstrapContext,
+) -> Result<Option<CodexAuthSource>, ProviderError> {
+    if config.provider_type != "openai" || config.auth_type != super::AuthType::OAuth {
+        return Ok(None);
+    }
+
+    let source = match bootstrap.gateway_mode {
+        GatewayBootstrapMode::InWorld => CodexAuthSource::Integrated,
+        GatewayBootstrapMode::HostOnly => CodexAuthSource::StandaloneLocal {
+            path: CodexAuthState::default_path().map_err(|e| {
+                ProviderError::ConfigError(format!(
+                    "Failed to resolve standalone Codex auth path for provider '{}': {}",
+                    config.name, e
+                ))
+            })?,
+        },
+    };
+
+    Ok(Some(source))
+}
 
 /// Provider registry that manages all configured providers
 pub struct ProviderRegistry {
@@ -46,6 +114,16 @@ impl ProviderRegistry {
         token_store: Option<TokenStore>,
         models: &[ModelConfig],
     ) -> Result<Self, ProviderError> {
+        let bootstrap = ProviderBootstrapContext::from_env()?;
+        Self::from_configs_with_models_and_bootstrap(configs, token_store, models, bootstrap)
+    }
+
+    fn from_configs_with_models_and_bootstrap(
+        configs: &[ProviderConfig],
+        token_store: Option<TokenStore>,
+        models: &[ModelConfig],
+        bootstrap: ProviderBootstrapContext,
+    ) -> Result<Self, ProviderError> {
         let mut registry = Self::new();
 
         for config in configs {
@@ -72,6 +150,8 @@ impl ProviderRegistry {
                 }
             };
 
+            let codex_auth_source = codex_auth_source_for_openai_oauth(config, bootstrap)?;
+
             // Create provider instance based on type
             let provider: Box<dyn GatewayProvider> = match config.provider_type.as_str() {
                 // OpenAI-compatible providers (unified with custom headers support)
@@ -95,6 +175,7 @@ impl ProviderRegistry {
                         custom_headers,
                         oauth_provider: config.oauth_provider.clone(),
                         token_store: token_store.clone(),
+                        codex_auth_source,
                     }))
                 }
 
@@ -126,6 +207,7 @@ impl ProviderRegistry {
                             custom_headers,
                             oauth_provider: config.oauth_provider.clone(),
                             token_store: token_store.clone(),
+                            codex_auth_source: None,
                         },
                     ))
                 }
@@ -147,6 +229,7 @@ impl ProviderRegistry {
                     ],
                     oauth_provider: config.oauth_provider.clone(),
                     token_store: token_store.clone(),
+                    codex_auth_source: None,
                 })),
 
                 // Deprecated aliases for OpenAI-compatible providers
@@ -202,6 +285,7 @@ impl ProviderRegistry {
                         custom_headers: headers_vec,
                         oauth_provider: config.oauth_provider.clone(),
                         token_store: token_store.clone(),
+                        codex_auth_source: None,
                     }))
                 }
 

--- a/crates/gateway/src/server/mod.rs
+++ b/crates/gateway/src/server/mod.rs
@@ -115,7 +115,10 @@ fn classify_provider_error(error: &ProviderError) -> FailureClass {
             let lowered = message.to_ascii_lowercase();
             if lowered.contains("url") || lowered.contains("base_url") {
                 FailureClass::Url
-            } else if lowered.contains("codex route") {
+            } else if lowered.contains("codex route")
+                || lowered.contains("authoritative provenance")
+                || lowered.contains("prior function_call")
+            {
                 FailureClass::Route
             } else {
                 FailureClass::TransportDrift

--- a/crates/gateway/src/server/mod.rs
+++ b/crates/gateway/src/server/mod.rs
@@ -115,6 +115,8 @@ fn classify_provider_error(error: &ProviderError) -> FailureClass {
             let lowered = message.to_ascii_lowercase();
             if lowered.contains("url") || lowered.contains("base_url") {
                 FailureClass::Url
+            } else if lowered.contains("codex route") {
+                FailureClass::Route
             } else {
                 FailureClass::TransportDrift
             }

--- a/crates/gateway/src/server/openai_responses.rs
+++ b/crates/gateway/src/server/openai_responses.rs
@@ -29,6 +29,19 @@ use super::{
 
 const OPENAI_PUBLIC_RESPONSES_METADATA_KEY: &str = "openai_public_responses";
 const OPENAI_RESPONSES_TOOL_CHOICE_METADATA_KEY: &str = "openai_responses_tool_choice";
+const OPENAI_RESPONSES_REASONING_EFFORT_METADATA_KEY: &str = "openai_responses_reasoning_effort";
+const OPENAI_RESPONSES_REASONING_SUMMARY_METADATA_KEY: &str = "openai_responses_reasoning_summary";
+const OPENAI_RESPONSES_INCLUDE_METADATA_KEY: &str = "openai_responses_include";
+const OPENAI_RESPONSES_TEXT_VERBOSITY_METADATA_KEY: &str = "openai_responses_text_verbosity";
+const OPENAI_RESPONSES_EXPLICIT_MAX_OUTPUT_TOKENS_METADATA_KEY: &str =
+    "openai_responses_explicit_max_output_tokens";
+const OPENAI_RESPONSES_INPUT_METADATA_METADATA_KEY: &str = "openai_responses_input_metadata";
+const OPENAI_RESPONSES_TRUNCATION_METADATA_KEY: &str = "openai_responses_truncation";
+const OPENAI_RESPONSES_PREVIOUS_RESPONSE_ID_METADATA_KEY: &str =
+    "openai_responses_previous_response_id";
+const OPENAI_RESPONSES_USER_METADATA_KEY: &str = "openai_responses_user";
+const OPENAI_RESPONSES_STREAM_OPTIONS_METADATA_KEY: &str = "openai_responses_stream_options";
+const OPENAI_RESPONSES_SERVICE_TIER_METADATA_KEY: &str = "openai_responses_service_tier";
 
 #[derive(Debug, Deserialize)]
 #[allow(dead_code)]
@@ -44,7 +57,13 @@ struct OpenAIResponsesRequest {
     #[serde(default)]
     text: Option<OpenAIResponsesText>,
     #[serde(default)]
+    include: Option<Vec<String>>,
+    #[serde(default)]
+    reasoning: Option<OpenAIResponsesReasoning>,
+    #[serde(default)]
     max_output_tokens: Option<u32>,
+    #[serde(default)]
+    metadata: Option<HashMap<String, serde_json::Value>>,
     #[serde(default)]
     temperature: Option<f32>,
     #[serde(default)]
@@ -52,9 +71,17 @@ struct OpenAIResponsesRequest {
     #[serde(default)]
     stop: Option<Vec<String>>,
     #[serde(default)]
+    truncation: Option<serde_json::Value>,
+    #[serde(default)]
+    previous_response_id: Option<String>,
+    #[serde(default)]
+    user: Option<String>,
+    #[serde(default)]
     stream: Option<bool>,
     #[serde(default)]
     stream_options: Option<OpenAIResponsesStreamOptions>,
+    #[serde(default)]
+    service_tier: Option<serde_json::Value>,
 }
 
 #[derive(Debug, Deserialize)]
@@ -135,7 +162,10 @@ struct OpenAIResponsesToolChoiceFunction {
 
 #[derive(Debug, Deserialize)]
 struct OpenAIResponsesText {
+    #[serde(default)]
     format: Option<OpenAIResponsesTextFormat>,
+    #[serde(default)]
+    verbosity: Option<String>,
 }
 
 #[derive(Debug, Deserialize)]
@@ -145,6 +175,13 @@ struct OpenAIResponsesTextFormat {
 }
 
 #[derive(Debug, Deserialize)]
+struct OpenAIResponsesReasoning {
+    effort: String,
+    #[serde(default)]
+    summary: Option<String>,
+}
+
+#[derive(Debug, Deserialize, Serialize)]
 struct OpenAIResponsesStreamOptions {
     #[allow(dead_code)]
     #[serde(default)]
@@ -267,12 +304,96 @@ fn transform_openai_to_gateway_request(
             serde_json::to_value(tool_choice).map_err(|err| err.to_string())?,
         );
     }
+    if let Some(max_output_tokens) = openai_req.max_output_tokens {
+        metadata.insert(
+            OPENAI_RESPONSES_EXPLICIT_MAX_OUTPUT_TOKENS_METADATA_KEY.to_string(),
+            serde_json::Value::from(max_output_tokens),
+        );
+    }
+    if let Some(request_metadata) = &openai_req.metadata {
+        metadata.insert(
+            OPENAI_RESPONSES_INPUT_METADATA_METADATA_KEY.to_string(),
+            serde_json::to_value(request_metadata).map_err(|err| err.to_string())?,
+        );
+    }
+    if let Some(truncation) = &openai_req.truncation {
+        metadata.insert(
+            OPENAI_RESPONSES_TRUNCATION_METADATA_KEY.to_string(),
+            truncation.clone(),
+        );
+    }
+    if let Some(previous_response_id) = &openai_req.previous_response_id {
+        metadata.insert(
+            OPENAI_RESPONSES_PREVIOUS_RESPONSE_ID_METADATA_KEY.to_string(),
+            serde_json::Value::String(previous_response_id.clone()),
+        );
+    }
+    if let Some(user) = &openai_req.user {
+        metadata.insert(
+            OPENAI_RESPONSES_USER_METADATA_KEY.to_string(),
+            serde_json::Value::String(user.clone()),
+        );
+    }
+    if let Some(stream_options) = &openai_req.stream_options {
+        metadata.insert(
+            OPENAI_RESPONSES_STREAM_OPTIONS_METADATA_KEY.to_string(),
+            serde_json::to_value(stream_options).map_err(|err| err.to_string())?,
+        );
+    }
+    if let Some(service_tier) = &openai_req.service_tier {
+        metadata.insert(
+            OPENAI_RESPONSES_SERVICE_TIER_METADATA_KEY.to_string(),
+            service_tier.clone(),
+        );
+    }
+    if let Some(reasoning) = &openai_req.reasoning {
+        metadata.insert(
+            OPENAI_RESPONSES_REASONING_EFFORT_METADATA_KEY.to_string(),
+            serde_json::Value::String(reasoning.effort.clone()),
+        );
+        if let Some(summary) = &reasoning.summary {
+            metadata.insert(
+                OPENAI_RESPONSES_REASONING_SUMMARY_METADATA_KEY.to_string(),
+                serde_json::Value::String(summary.clone()),
+            );
+        }
+    }
+    if let Some(include) = &openai_req.include {
+        metadata.insert(
+            OPENAI_RESPONSES_INCLUDE_METADATA_KEY.to_string(),
+            serde_json::Value::Array(
+                include
+                    .iter()
+                    .cloned()
+                    .map(serde_json::Value::String)
+                    .collect(),
+            ),
+        );
+    }
+    if let Some(text) = &openai_req.text {
+        if let Some(verbosity) = &text.verbosity {
+            metadata.insert(
+                OPENAI_RESPONSES_TEXT_VERBOSITY_METADATA_KEY.to_string(),
+                serde_json::Value::String(verbosity.clone()),
+            );
+        }
+    }
 
     Ok(GatewayRequest {
         model: openai_req.model,
         messages,
         max_output_tokens: openai_req.max_output_tokens.unwrap_or(4096),
-        reasoning: None,
+        reasoning: openai_req
+            .reasoning
+            .as_ref()
+            .map(|reasoning| crate::core::ReasoningConfig {
+                r#type: if reasoning.effort == "none" {
+                    "disabled".to_string()
+                } else {
+                    "enabled".to_string()
+                },
+                budget_tokens: None,
+            }),
         temperature: openai_req.temperature,
         top_p: openai_req.top_p,
         top_k: None,

--- a/crates/gateway/src/server/openai_responses.rs
+++ b/crates/gateway/src/server/openai_responses.rs
@@ -1420,6 +1420,7 @@ mod tests {
     use super::*;
     use crate::cli::ModelMapping;
     use crate::providers::ProviderRegistry;
+    use crate::providers::{OpenAIProvider, OpenAIProviderConfig, OpenAITransport};
     use crate::server::openai_conformance_test_support::{
         read_json_fixture, response_text_response as response_text,
         response_with_text_and_tool as response_with_tool_and_thinking, ConformanceHarness,
@@ -1693,6 +1694,62 @@ mod tests {
             Some(vec!["halt".to_string()])
         );
         assert_eq!(gateway_request.tools.as_ref().unwrap().len(), 1);
+    }
+
+    #[test]
+    fn public_responses_passthrough_controls_survive_ingress_and_provider_serialization() {
+        let request: OpenAIResponsesRequest = serde_json::from_value(json!({
+            "model": "gpt-test",
+            "input": "hello",
+            "metadata": {
+                "client": "sdk",
+                "request_id": "req_123"
+            },
+            "truncation": "auto",
+            "previous_response_id": "resp_prev_123",
+            "user": "user_123",
+            "stream_options": { "include_obfuscation": true },
+            "service_tier": "priority"
+        }))
+        .unwrap();
+
+        let gateway_request = transform_openai_to_gateway_request(request).unwrap();
+        let provider = OpenAIProvider::with_transport(
+            OpenAITransport::OpenAI,
+            OpenAIProviderConfig {
+                name: "test-openai".to_string(),
+                api_key: String::new(),
+                base_url: "https://example.invalid/v1".to_string(),
+                models: Vec::new(),
+                custom_headers: Vec::new(),
+                oauth_provider: None,
+                token_store: None,
+                codex_auth_source: None,
+            },
+        );
+
+        let serialized = serde_json::to_value(
+            provider
+                .transform_to_responses_request(&gateway_request)
+                .unwrap(),
+        )
+        .unwrap();
+
+        assert_eq!(
+            serialized["metadata"],
+            json!({
+                "client": "sdk",
+                "request_id": "req_123"
+            })
+        );
+        assert_eq!(serialized["truncation"], json!("auto"));
+        assert_eq!(serialized["previous_response_id"], json!("resp_prev_123"));
+        assert_eq!(serialized["user"], json!("user_123"));
+        assert_eq!(
+            serialized["stream_options"],
+            json!({ "include_obfuscation": true })
+        );
+        assert_eq!(serialized["service_tier"], json!("priority"));
     }
 
     #[test]

--- a/crates/gateway/src/server/openai_responses.rs
+++ b/crates/gateway/src/server/openai_responses.rs
@@ -243,6 +243,7 @@ fn transform_openai_to_gateway_request(
     openai_req: OpenAIResponsesRequest,
 ) -> Result<GatewayRequest, String> {
     reject_known_unsupported_request_state(&openai_req)?;
+    let allows_previous_response_continuation = openai_req.previous_response_id.is_some();
 
     let (tools, tool_names) = parse_function_tools(openai_req.tools.as_ref())?;
     let tool_choice = openai_req.tool_choice.as_ref();
@@ -305,7 +306,9 @@ fn transform_openai_to_gateway_request(
                                 "function_call_output.call_id must not be empty".to_string()
                             );
                         }
-                        if !prior_function_call_ids.contains(function_call_output.call_id.trim()) {
+                        if !prior_function_call_ids.contains(function_call_output.call_id.trim())
+                            && !allows_previous_response_continuation
+                        {
                             return Err(
                                 "function_call_output.call_id must reference a prior function_call item"
                                     .to_string(),
@@ -1634,6 +1637,42 @@ mod tests {
 
         let err = transform_openai_to_gateway_request(request).unwrap_err();
         assert_eq!(err, "function_call.arguments must be a JSON string");
+    }
+
+    #[test]
+    fn previous_response_id_allows_function_call_output_without_same_request_function_call() {
+        let request: OpenAIResponsesRequest = serde_json::from_value(json!({
+            "model": "gpt-test",
+            "previous_response_id": "resp_prev_123",
+            "input": [
+                {
+                    "type": "function_call_output",
+                    "call_id": "call_123",
+                    "output": "tool-output"
+                }
+            ]
+        }))
+        .unwrap();
+
+        let gateway_request = transform_openai_to_gateway_request(request).unwrap();
+        assert_eq!(gateway_request.messages.len(), 1);
+        assert_eq!(gateway_request.messages[0].role, "user");
+        assert!(matches!(
+            gateway_request.messages[0].content,
+            MessageContent::Blocks(ref blocks)
+                if matches!(
+                    &blocks[0],
+                    ContentBlock::Known(KnownContentBlock::ToolResult { tool_use_id, content, .. })
+                    if tool_use_id == "call_123"
+                        && matches!(content, ToolResultContent::Text(text) if text == "tool-output")
+                )
+        ));
+        assert_eq!(
+            gateway_request.metadata.as_ref().and_then(
+                |metadata| metadata.get(OPENAI_RESPONSES_PREVIOUS_RESPONSE_ID_METADATA_KEY)
+            ),
+            Some(&json!("resp_prev_123"))
+        );
     }
 
     #[test]

--- a/crates/gateway/src/server/openai_responses.rs
+++ b/crates/gateway/src/server/openai_responses.rs
@@ -28,6 +28,7 @@ use super::{
 };
 
 const OPENAI_PUBLIC_RESPONSES_METADATA_KEY: &str = "openai_public_responses";
+const OPENAI_RESPONSES_TOOL_CHOICE_METADATA_KEY: &str = "openai_responses_tool_choice";
 
 #[derive(Debug, Deserialize)]
 #[allow(dead_code)]
@@ -113,21 +114,21 @@ struct OpenAIResponsesToolFunction {
     parameters: Option<serde_json::Value>,
 }
 
-#[derive(Debug, Deserialize)]
+#[derive(Debug, Deserialize, Serialize)]
 #[serde(untagged)]
 enum OpenAIResponsesToolChoice {
     String(String),
     Object(OpenAIResponsesToolChoiceObject),
 }
 
-#[derive(Debug, Deserialize)]
+#[derive(Debug, Deserialize, Serialize)]
 struct OpenAIResponsesToolChoiceObject {
     #[serde(rename = "type")]
     r#type: String,
     function: OpenAIResponsesToolChoiceFunction,
 }
 
-#[derive(Debug, Deserialize)]
+#[derive(Debug, Deserialize, Serialize)]
 struct OpenAIResponsesToolChoiceFunction {
     name: String,
 }
@@ -198,7 +199,8 @@ fn transform_openai_to_gateway_request(
     reject_known_unsupported_request_state(&openai_req)?;
 
     let (tools, tool_names) = parse_function_tools(openai_req.tools.as_ref())?;
-    let tools = apply_tool_choice(tools, &tool_names, openai_req.tool_choice.as_ref())?;
+    let tool_choice = openai_req.tool_choice.as_ref();
+    let tools = apply_tool_choice(tools, &tool_names, tool_choice)?;
 
     let mut messages = Vec::new();
 
@@ -257,6 +259,12 @@ fn transform_openai_to_gateway_request(
         metadata.insert(
             "parallel_tool_calls".to_string(),
             serde_json::Value::Bool(parallel_tool_calls),
+        );
+    }
+    if let Some(tool_choice) = tool_choice {
+        metadata.insert(
+            OPENAI_RESPONSES_TOOL_CHOICE_METADATA_KEY.to_string(),
+            serde_json::to_value(tool_choice).map_err(|err| err.to_string())?,
         );
     }
 
@@ -1413,6 +1421,34 @@ mod tests {
         }))
         .unwrap();
         assert!(transform_openai_to_gateway_request(rejected).is_err());
+    }
+
+    #[test]
+    fn generic_public_responses_controls_remain_accepted_at_ingress() {
+        let request: OpenAIResponsesRequest = serde_json::from_value(json!({
+            "model": "gpt-test",
+            "input": "hello",
+            "max_output_tokens": 128,
+            "temperature": 0.2,
+            "top_p": 0.8,
+            "stop": ["halt"],
+            "stream_options": { "include_obfuscation": true },
+            "tools": [
+                { "type": "function", "function": { "name": "lookup", "parameters": {"type":"object"} } }
+            ],
+            "tool_choice": {"type":"function","function":{"name":"lookup"}}
+        }))
+        .unwrap();
+
+        let gateway_request = transform_openai_to_gateway_request(request).unwrap();
+        assert_eq!(gateway_request.max_output_tokens, 128);
+        assert_eq!(gateway_request.temperature, Some(0.2));
+        assert_eq!(gateway_request.top_p, Some(0.8));
+        assert_eq!(
+            gateway_request.stop_sequences,
+            Some(vec!["halt".to_string()])
+        );
+        assert_eq!(gateway_request.tools.as_ref().unwrap().len(), 1);
     }
 
     #[test]

--- a/crates/gateway/src/server/openai_responses.rs
+++ b/crates/gateway/src/server/openai_responses.rs
@@ -96,6 +96,8 @@ enum OpenAIResponsesInput {
 enum OpenAIResponsesInputItem {
     #[serde(rename = "message")]
     Message(OpenAIResponsesMessageItem),
+    #[serde(rename = "function_call")]
+    FunctionCall(OpenAIResponsesFunctionCallItem),
     #[serde(rename = "function_call_output")]
     FunctionCallOutput(OpenAIResponsesFunctionCallOutputItem),
 }
@@ -123,6 +125,13 @@ enum OpenAIResponsesMessageContentPart {
 struct OpenAIResponsesFunctionCallOutputItem {
     call_id: String,
     output: String,
+}
+
+#[derive(Debug, Deserialize)]
+struct OpenAIResponsesFunctionCallItem {
+    call_id: String,
+    name: String,
+    arguments: String,
 }
 
 #[derive(Debug, Deserialize)]
@@ -249,6 +258,8 @@ fn transform_openai_to_gateway_request(
             });
         }
         OpenAIResponsesInput::Items(items) => {
+            let mut prior_function_call_ids = HashSet::new();
+
             for item in items {
                 match item {
                     OpenAIResponsesInputItem::Message(message) => {
@@ -263,10 +274,41 @@ fn transform_openai_to_gateway_request(
                             other => return Err(format!("Unsupported message role: {other}")),
                         }
                     }
+                    OpenAIResponsesInputItem::FunctionCall(function_call) => {
+                        let call_id = function_call.call_id.trim();
+                        if call_id.is_empty() {
+                            return Err("function_call.call_id must not be empty".to_string());
+                        }
+                        let name = function_call.name.trim();
+                        if name.is_empty() {
+                            return Err("function_call.name must not be empty".to_string());
+                        }
+
+                        let arguments =
+                            parse_responses_function_call_arguments(&function_call.arguments)?;
+                        prior_function_call_ids.insert(call_id.to_string());
+
+                        messages.push(Message {
+                            role: "assistant".to_string(),
+                            content: MessageContent::Blocks(vec![ContentBlock::Known(
+                                KnownContentBlock::ToolUse {
+                                    id: call_id.to_string(),
+                                    name: name.to_string(),
+                                    input: arguments,
+                                },
+                            )]),
+                        });
+                    }
                     OpenAIResponsesInputItem::FunctionCallOutput(function_call_output) => {
                         if function_call_output.call_id.trim().is_empty() {
                             return Err(
                                 "function_call_output.call_id must not be empty".to_string()
+                            );
+                        }
+                        if !prior_function_call_ids.contains(function_call_output.call_id.trim()) {
+                            return Err(
+                                "function_call_output.call_id must reference a prior function_call item"
+                                    .to_string(),
                             );
                         }
 
@@ -1332,6 +1374,11 @@ fn responses_message_content_to_message_content(
     }
 }
 
+fn parse_responses_function_call_arguments(arguments: &str) -> Result<serde_json::Value, String> {
+    serde_json::from_str(arguments)
+        .map_err(|_| "function_call.arguments must be a JSON string".to_string())
+}
+
 fn image_source_from_url(image_url: &str) -> Result<ImageSource, String> {
     if image_url.starts_with("data:") {
         if let Some(comma_idx) = image_url.find(',') {
@@ -1416,7 +1463,7 @@ mod tests {
     }
 
     #[test]
-    fn message_items_and_function_call_outputs_map_into_the_normalized_core() {
+    fn message_items_function_calls_and_outputs_map_into_the_normalized_core() {
         let request: OpenAIResponsesRequest = serde_json::from_value(json!({
             "model": "gpt-test",
             "input": [
@@ -1446,6 +1493,12 @@ mod tests {
                     ]
                 },
                 {
+                    "type": "function_call",
+                    "call_id": "call_123",
+                    "name": "lookup",
+                    "arguments": "{\"query\":\"question\"}"
+                },
+                {
                     "type": "function_call_output",
                     "call_id": "call_123",
                     "output": "tool-output"
@@ -1456,7 +1509,7 @@ mod tests {
 
         let gateway_request = transform_openai_to_gateway_request(request).unwrap();
         assert!(gateway_request.system.is_none());
-        assert_eq!(gateway_request.messages.len(), 4);
+        assert_eq!(gateway_request.messages.len(), 5);
 
         assert_eq!(gateway_request.messages[0].role, "system");
         match &gateway_request.messages[0].content {
@@ -1500,9 +1553,22 @@ mod tests {
             _ => panic!("expected blocks"),
         }
 
-        assert_eq!(gateway_request.messages[3].role, "user");
+        assert_eq!(gateway_request.messages[3].role, "assistant");
         assert!(matches!(
             gateway_request.messages[3].content,
+            MessageContent::Blocks(ref blocks)
+                if matches!(
+                    &blocks[0],
+                    ContentBlock::Known(KnownContentBlock::ToolUse { id, name, input })
+                    if id == "call_123"
+                        && name == "lookup"
+                        && input == &serde_json::json!({"query":"question"})
+                )
+        ));
+
+        assert_eq!(gateway_request.messages[4].role, "user");
+        assert!(matches!(
+            gateway_request.messages[4].content,
             MessageContent::Blocks(ref blocks)
                 if matches!(
                     &blocks[0],
@@ -1510,6 +1576,63 @@ mod tests {
                     if tool_use_id == "call_123" && matches!(content, ToolResultContent::Text(text) if text == "tool-output")
                 )
         ));
+    }
+
+    #[test]
+    fn invalid_function_call_call_id_is_rejected() {
+        let request: OpenAIResponsesRequest = serde_json::from_value(json!({
+            "model": "gpt-test",
+            "input": [
+                {
+                    "type": "function_call",
+                    "call_id": "",
+                    "name": "lookup",
+                    "arguments": "{}"
+                }
+            ]
+        }))
+        .unwrap();
+
+        let err = transform_openai_to_gateway_request(request).unwrap_err();
+        assert_eq!(err, "function_call.call_id must not be empty");
+    }
+
+    #[test]
+    fn invalid_function_call_name_is_rejected() {
+        let request: OpenAIResponsesRequest = serde_json::from_value(json!({
+            "model": "gpt-test",
+            "input": [
+                {
+                    "type": "function_call",
+                    "call_id": "call_123",
+                    "name": "",
+                    "arguments": "{}"
+                }
+            ]
+        }))
+        .unwrap();
+
+        let err = transform_openai_to_gateway_request(request).unwrap_err();
+        assert_eq!(err, "function_call.name must not be empty");
+    }
+
+    #[test]
+    fn invalid_function_call_arguments_are_rejected() {
+        let request: OpenAIResponsesRequest = serde_json::from_value(json!({
+            "model": "gpt-test",
+            "input": [
+                {
+                    "type": "function_call",
+                    "call_id": "call_123",
+                    "name": "lookup",
+                    "arguments": "not-json"
+                }
+            ]
+        }))
+        .unwrap();
+
+        let err = transform_openai_to_gateway_request(request).unwrap_err();
+        assert_eq!(err, "function_call.arguments must be a JSON string");
     }
 
     #[test]
@@ -1683,6 +1806,8 @@ mod tests {
     struct ToolLoopRequestFixture {
         request: serde_json::Value,
         expected_tool_use_id: String,
+        expected_tool_name: String,
+        expected_arguments: serde_json::Value,
         expected_output: String,
     }
 
@@ -1862,6 +1987,17 @@ mod tests {
         let request: OpenAIResponsesRequest = serde_json::from_value(fixture.request).unwrap();
         let gateway_request = transform_openai_to_gateway_request(request).unwrap();
 
+        assert!(matches!(
+            gateway_request.messages[1].content,
+            MessageContent::Blocks(ref blocks)
+                if matches!(
+                    &blocks[0],
+                    ContentBlock::Known(KnownContentBlock::ToolUse { id, name, input })
+                    if id == &fixture.expected_tool_use_id
+                        && name == &fixture.expected_tool_name
+                        && input == &fixture.expected_arguments
+                )
+        ));
         assert!(matches!(
             gateway_request.messages.last().unwrap().content,
             MessageContent::Blocks(ref blocks)

--- a/crates/gateway/tests/fixtures/openai_responses/codex-negative-built-in-tool.json
+++ b/crates/gateway/tests/fixtures/openai_responses/codex-negative-built-in-tool.json
@@ -1,0 +1,18 @@
+{
+  "request": {
+    "model": "gateway-default",
+    "input": "hello",
+    "tools": [
+      {
+        "type": "web_search",
+        "function": {
+          "name": "ignored"
+        }
+      }
+    ]
+  },
+  "expected_error_contains": "Only function tools are supported",
+  "expected_status": 400,
+  "expected_error_class": "route",
+  "expected_error_message": "Route selection failed"
+}

--- a/crates/gateway/tests/fixtures/openai_responses/codex-negative-encrypted-include-without-reasoning.json
+++ b/crates/gateway/tests/fixtures/openai_responses/codex-negative-encrypted-include-without-reasoning.json
@@ -1,0 +1,13 @@
+{
+  "request": {
+    "model": "gateway-default",
+    "input": "hello",
+    "include": [
+      "reasoning.encrypted_content"
+    ]
+  },
+  "expected_error_contains": "include reasoning.encrypted_content requires reasoning.effort to be enabled",
+  "expected_status": 502,
+  "expected_error_class": "route",
+  "expected_error_message": "Route selection failed"
+}

--- a/crates/gateway/tests/fixtures/openai_responses/codex-negative-invalid-call-id.json
+++ b/crates/gateway/tests/fixtures/openai_responses/codex-negative-invalid-call-id.json
@@ -1,0 +1,16 @@
+{
+  "request": {
+    "model": "gateway-default",
+    "input": [
+      {
+        "type": "function_call_output",
+        "call_id": "",
+        "output": "{\"ok\":true}"
+      }
+    ]
+  },
+  "expected_error_contains": "function_call_output.call_id must not be empty",
+  "expected_status": 400,
+  "expected_error_class": "route",
+  "expected_error_message": "Route selection failed"
+}

--- a/crates/gateway/tests/fixtures/openai_responses/codex-negative-invalid-function-call-arguments.json
+++ b/crates/gateway/tests/fixtures/openai_responses/codex-negative-invalid-function-call-arguments.json
@@ -1,0 +1,17 @@
+{
+  "request": {
+    "model": "gateway-default",
+    "input": [
+      {
+        "type": "function_call",
+        "call_id": "call_bad_args",
+        "name": "lookup",
+        "arguments": "not-json"
+      }
+    ]
+  },
+  "expected_error_contains": "function_call.arguments must be a JSON string",
+  "expected_status": 400,
+  "expected_error_class": "route",
+  "expected_error_message": "Route selection failed"
+}

--- a/crates/gateway/tests/fixtures/openai_responses/codex-negative-invalid-reasoning-summary.json
+++ b/crates/gateway/tests/fixtures/openai_responses/codex-negative-invalid-reasoning-summary.json
@@ -1,0 +1,14 @@
+{
+  "request": {
+    "model": "gateway-default",
+    "input": "hello",
+    "reasoning": {
+      "effort": "none",
+      "summary": "concise"
+    }
+  },
+  "expected_error_contains": "reasoning.summary requires reasoning.effort to be enabled",
+  "expected_status": 502,
+  "expected_error_class": "route",
+  "expected_error_message": "Route selection failed"
+}

--- a/crates/gateway/tests/fixtures/openai_responses/codex-negative-max-output-tokens.json
+++ b/crates/gateway/tests/fixtures/openai_responses/codex-negative-max-output-tokens.json
@@ -1,0 +1,11 @@
+{
+  "request": {
+    "model": "gateway-default",
+    "input": "hello",
+    "max_output_tokens": 64
+  },
+  "expected_error_contains": "max_output_tokens is not supported on the Codex route",
+  "expected_status": 502,
+  "expected_error_class": "route",
+  "expected_error_message": "Route selection failed"
+}

--- a/crates/gateway/tests/fixtures/openai_responses/codex-negative-metadata.json
+++ b/crates/gateway/tests/fixtures/openai_responses/codex-negative-metadata.json
@@ -1,0 +1,13 @@
+{
+  "request": {
+    "model": "gateway-default",
+    "input": "hello",
+    "metadata": {
+      "trace_id": "abc123"
+    }
+  },
+  "expected_error_contains": "metadata is not supported on the Codex route",
+  "expected_status": 502,
+  "expected_error_class": "route",
+  "expected_error_message": "Route selection failed"
+}

--- a/crates/gateway/tests/fixtures/openai_responses/codex-negative-non-function-tool.json
+++ b/crates/gateway/tests/fixtures/openai_responses/codex-negative-non-function-tool.json
@@ -1,0 +1,18 @@
+{
+  "request": {
+    "model": "gateway-default",
+    "input": "hello",
+    "tools": [
+      {
+        "type": "code_interpreter",
+        "function": {
+          "name": "ignored"
+        }
+      }
+    ]
+  },
+  "expected_error_contains": "Only function tools are supported",
+  "expected_status": 400,
+  "expected_error_class": "route",
+  "expected_error_message": "Route selection failed"
+}

--- a/crates/gateway/tests/fixtures/openai_responses/codex-negative-previous-response-id.json
+++ b/crates/gateway/tests/fixtures/openai_responses/codex-negative-previous-response-id.json
@@ -1,0 +1,11 @@
+{
+  "request": {
+    "model": "gateway-default",
+    "input": "hello",
+    "previous_response_id": "resp_prev"
+  },
+  "expected_error_contains": "previous_response_id is not supported on the Codex route",
+  "expected_status": 502,
+  "expected_error_class": "route",
+  "expected_error_message": "Route selection failed"
+}

--- a/crates/gateway/tests/fixtures/openai_responses/codex-negative-required-tool-choice.json
+++ b/crates/gateway/tests/fixtures/openai_responses/codex-negative-required-tool-choice.json
@@ -1,0 +1,22 @@
+{
+  "request": {
+    "model": "gateway-default",
+    "input": "hello",
+    "tools": [
+      {
+        "type": "function",
+        "function": {
+          "name": "lookup",
+          "parameters": {
+            "type": "object"
+          }
+        }
+      }
+    ],
+    "tool_choice": "required"
+  },
+  "expected_error_contains": "tool_choice=\"required\" is not supported on the Codex route",
+  "expected_status": 502,
+  "expected_error_class": "route",
+  "expected_error_message": "Route selection failed"
+}

--- a/crates/gateway/tests/fixtures/openai_responses/codex-negative-service-tier.json
+++ b/crates/gateway/tests/fixtures/openai_responses/codex-negative-service-tier.json
@@ -1,0 +1,11 @@
+{
+  "request": {
+    "model": "gateway-default",
+    "input": "hello",
+    "service_tier": "priority"
+  },
+  "expected_error_contains": "service_tier is not supported on the Codex route",
+  "expected_status": 502,
+  "expected_error_class": "route",
+  "expected_error_message": "Route selection failed"
+}

--- a/crates/gateway/tests/fixtures/openai_responses/codex-negative-stream-options.json
+++ b/crates/gateway/tests/fixtures/openai_responses/codex-negative-stream-options.json
@@ -1,0 +1,13 @@
+{
+  "request": {
+    "model": "gateway-default",
+    "input": "hello",
+    "stream_options": {
+      "include_obfuscation": true
+    }
+  },
+  "expected_error_contains": "stream_options is not supported on the Codex route",
+  "expected_status": 502,
+  "expected_error_class": "route",
+  "expected_error_message": "Route selection failed"
+}

--- a/crates/gateway/tests/fixtures/openai_responses/codex-negative-temperature.json
+++ b/crates/gateway/tests/fixtures/openai_responses/codex-negative-temperature.json
@@ -1,0 +1,11 @@
+{
+  "request": {
+    "model": "gateway-default",
+    "input": "hello",
+    "temperature": 0.2
+  },
+  "expected_error_contains": "temperature is not supported on the Codex route",
+  "expected_status": 502,
+  "expected_error_class": "route",
+  "expected_error_message": "Route selection failed"
+}

--- a/crates/gateway/tests/fixtures/openai_responses/codex-negative-top-p.json
+++ b/crates/gateway/tests/fixtures/openai_responses/codex-negative-top-p.json
@@ -1,0 +1,11 @@
+{
+  "request": {
+    "model": "gateway-default",
+    "input": "hello",
+    "top_p": 0.5
+  },
+  "expected_error_contains": "top_p is not supported on the Codex route",
+  "expected_status": 502,
+  "expected_error_class": "route",
+  "expected_error_message": "Route selection failed"
+}

--- a/crates/gateway/tests/fixtures/openai_responses/codex-negative-truncation.json
+++ b/crates/gateway/tests/fixtures/openai_responses/codex-negative-truncation.json
@@ -1,0 +1,11 @@
+{
+  "request": {
+    "model": "gateway-default",
+    "input": "hello",
+    "truncation": "auto"
+  },
+  "expected_error_contains": "truncation is not supported on the Codex route",
+  "expected_status": 502,
+  "expected_error_class": "route",
+  "expected_error_message": "Route selection failed"
+}

--- a/crates/gateway/tests/fixtures/openai_responses/codex-negative-unsupported-text-format.json
+++ b/crates/gateway/tests/fixtures/openai_responses/codex-negative-unsupported-text-format.json
@@ -1,0 +1,15 @@
+{
+  "request": {
+    "model": "gateway-default",
+    "input": "hello",
+    "text": {
+      "format": {
+        "type": "json_schema"
+      }
+    }
+  },
+  "expected_error_contains": "Unsupported text.format.type",
+  "expected_status": 400,
+  "expected_error_class": "route",
+  "expected_error_message": "Route selection failed"
+}

--- a/crates/gateway/tests/fixtures/openai_responses/codex-negative-user.json
+++ b/crates/gateway/tests/fixtures/openai_responses/codex-negative-user.json
@@ -1,0 +1,11 @@
+{
+  "request": {
+    "model": "gateway-default",
+    "input": "hello",
+    "user": "codex-user"
+  },
+  "expected_error_contains": "user is not supported on the Codex route",
+  "expected_status": 502,
+  "expected_error_class": "route",
+  "expected_error_message": "Route selection failed"
+}

--- a/crates/gateway/tests/fixtures/openai_responses/codex-request-tool-loop-function-call-output.json
+++ b/crates/gateway/tests/fixtures/openai_responses/codex-request-tool-loop-function-call-output.json
@@ -1,0 +1,24 @@
+{
+  "request": {
+    "model": "gateway-default",
+    "input": [
+      {
+        "type": "message",
+        "role": "assistant",
+        "content": [
+          {
+            "type": "input_text",
+            "text": "Need tool output."
+          }
+        ]
+      },
+      {
+        "type": "function_call_output",
+        "call_id": "call_fixture_1",
+        "output": "{\"ok\":true}"
+      }
+    ]
+  },
+  "expected_tool_use_id": "call_fixture_1",
+  "expected_output": "{\"ok\":true}"
+}

--- a/crates/gateway/tests/fixtures/openai_responses/codex-request-tool-loop-function-call-output.json
+++ b/crates/gateway/tests/fixtures/openai_responses/codex-request-tool-loop-function-call-output.json
@@ -13,6 +13,12 @@
         ]
       },
       {
+        "type": "function_call",
+        "call_id": "call_fixture_1",
+        "name": "lookup",
+        "arguments": "{\"query\":\"x\"}"
+      },
+      {
         "type": "function_call_output",
         "call_id": "call_fixture_1",
         "output": "{\"ok\":true}"
@@ -20,5 +26,9 @@
     ]
   },
   "expected_tool_use_id": "call_fixture_1",
+  "expected_tool_name": "lookup",
+  "expected_arguments": {
+    "query": "x"
+  },
   "expected_output": "{\"ok\":true}"
 }

--- a/crates/gateway/tests/fixtures/openai_responses/codex-stream-mixed.json
+++ b/crates/gateway/tests/fixtures/openai_responses/codex-stream-mixed.json
@@ -1,0 +1,59 @@
+{
+  "request": {
+    "model": "gateway-default",
+    "input": "hello",
+    "stream": true
+  },
+  "provider_stream_chunks": [
+    "event: message_start\ndata: {\"type\":\"message_start\",\"message\":{\"id\":\"msg_stream\",\"type\":\"message\",\"role\":\"assistant\",\"content\":[],\"model\":\"primary-actual\",\"stop_reason\":null,\"stop_sequence\":null,\"usage\":{\"input_tokens\":0,\"output_tokens\":0}}}\n\n",
+    "event: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"text_delta\",\"text\":\"Hello\"}}\n\n",
+    "event: content_block_stop\ndata: {\"type\":\"content_block_stop\",\"index\":0}\n\n",
+    "event: content_block_start\ndata: {\"type\":\"content_block_start\",\"index\":1,\"content_block\":{\"type\":\"tool_use\",\"id\":\"call_fixture_stream\",\"name\":\"lookup\",\"input\":{}}}\n\n",
+    "event: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":1,\"delta\":{\"type\":\"input_json_delta\",\"partial_json\":\"{\\\"path\\\":\\\"README.md\\\"}\"}}\n\n",
+    "event: content_block_stop\ndata: {\"type\":\"content_block_stop\",\"index\":1}\n\n",
+    "event: message_delta\ndata: {\"type\":\"message_delta\",\"delta\":{\"stop_reason\":\"tool_use\",\"stop_sequence\":null},\"usage\":{\"input_tokens\":10,\"output_tokens\":3}}\n\n",
+    "event: message_stop\ndata: {\"type\":\"message_stop\"}\n\n"
+  ],
+  "required_events": [
+    "response.created",
+    "response.output_item.added",
+    "response.content_part.added",
+    "response.output_text.delta",
+    "response.output_text.done",
+    "response.content_part.done",
+    "response.output_item.done",
+    "response.output_item.added",
+    "response.function_call_arguments.delta",
+    "response.function_call_arguments.done",
+    "response.output_item.done",
+    "response.completed"
+  ],
+  "expected_fragments": [
+    "\"call_id\":\"call_fixture_stream\"",
+    "\"model\":\"gateway-default\"",
+    "\"type\":\"response.completed\""
+  ],
+  "expected": {
+    "status": "completed",
+    "item_types": [
+      "message",
+      "function_call"
+    ],
+    "texts": [
+      "Hello"
+    ],
+    "call_ids": [
+      "call_fixture_stream"
+    ],
+    "usage": {
+      "input_tokens": 10,
+      "output_tokens": 3,
+      "total_tokens": 13
+    }
+  },
+  "forbidden_fragments": [
+    "event: content_block_",
+    "\"type\":\"message_delta\"",
+    "\"event_kind\":\"tool_intent\""
+  ]
+}

--- a/crates/gateway/tests/fixtures/openai_responses/codex-stream-text.json
+++ b/crates/gateway/tests/fixtures/openai_responses/codex-stream-text.json
@@ -1,0 +1,43 @@
+{
+  "request": {
+    "model": "gateway-default",
+    "input": "hello",
+    "stream": true
+  },
+  "provider_stream_chunks": [
+    "event: message_start\ndata: {\"type\":\"message_start\",\"message\":{\"id\":\"msg_stream_text\",\"type\":\"message\",\"role\":\"assistant\",\"content\":[],\"model\":\"primary-actual\",\"stop_reason\":null,\"stop_sequence\":null,\"usage\":{\"input_tokens\":0,\"output_tokens\":0}}}\n\n",
+    "event: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"text_delta\",\"text\":\"Stream text only.\"}}\n\n",
+    "event: message_delta\ndata: {\"type\":\"message_delta\",\"delta\":{\"stop_reason\":\"end_turn\",\"stop_sequence\":null}}\n\n",
+    "event: message_stop\ndata: {\"type\":\"message_stop\"}\n\n"
+  ],
+  "required_events": [
+    "response.created",
+    "response.output_item.added",
+    "response.content_part.added",
+    "response.output_text.delta",
+    "response.output_text.done",
+    "response.content_part.done",
+    "response.output_item.done",
+    "response.completed"
+  ],
+  "expected": {
+    "status": "completed",
+    "item_types": [
+      "message"
+    ],
+    "texts": [
+      "Stream text only."
+    ],
+    "call_ids": [],
+    "usage": {
+      "input_tokens": 0,
+      "output_tokens": 0,
+      "total_tokens": 0
+    }
+  },
+  "forbidden_fragments": [
+    "event: content_block_",
+    "\"type\":\"message_delta\"",
+    "\"event_kind\":\"tool_intent\""
+  ]
+}

--- a/crates/gateway/tests/fixtures/openai_responses/codex-stream-tool-call.json
+++ b/crates/gateway/tests/fixtures/openai_responses/codex-stream-tool-call.json
@@ -1,0 +1,43 @@
+{
+  "request": {
+    "model": "gateway-default",
+    "input": "hello",
+    "stream": true
+  },
+  "provider_stream_chunks": [
+    "event: message_start\ndata: {\"type\":\"message_start\",\"message\":{\"id\":\"msg_stream_tool\",\"type\":\"message\",\"role\":\"assistant\",\"content\":[],\"model\":\"primary-actual\",\"stop_reason\":null,\"stop_sequence\":null,\"usage\":{\"input_tokens\":0,\"output_tokens\":0}}}\n\n",
+    "event: content_block_start\ndata: {\"type\":\"content_block_start\",\"index\":0,\"content_block\":{\"type\":\"tool_use\",\"id\":\"call_fixture_stream_tool\",\"name\":\"lookup\",\"input\":{}}}\n\n",
+    "event: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"input_json_delta\",\"partial_json\":\"{\\\"path\\\":\\\"README.md\\\"}\"}}\n\n",
+    "event: content_block_stop\ndata: {\"type\":\"content_block_stop\",\"index\":0}\n\n",
+    "event: message_delta\ndata: {\"type\":\"message_delta\",\"delta\":{\"stop_reason\":\"tool_use\",\"stop_sequence\":null}}\n\n",
+    "event: message_stop\ndata: {\"type\":\"message_stop\"}\n\n"
+  ],
+  "required_events": [
+    "response.created",
+    "response.output_item.added",
+    "response.function_call_arguments.delta",
+    "response.function_call_arguments.done",
+    "response.output_item.done",
+    "response.completed"
+  ],
+  "expected": {
+    "status": "completed",
+    "item_types": [
+      "function_call"
+    ],
+    "texts": [],
+    "call_ids": [
+      "call_fixture_stream_tool"
+    ],
+    "usage": {
+      "input_tokens": 0,
+      "output_tokens": 0,
+      "total_tokens": 0
+    }
+  },
+  "forbidden_fragments": [
+    "event: content_block_",
+    "\"type\":\"message_delta\"",
+    "\"event_kind\":\"tool_intent\""
+  ]
+}

--- a/crates/gateway/tests/fixtures/openai_responses/codex-stream-with-usage.json
+++ b/crates/gateway/tests/fixtures/openai_responses/codex-stream-with-usage.json
@@ -1,0 +1,43 @@
+{
+  "request": {
+    "model": "gateway-default",
+    "input": "hello",
+    "stream": true
+  },
+  "provider_stream_chunks": [
+    "event: message_start\ndata: {\"type\":\"message_start\",\"message\":{\"id\":\"msg_stream_usage\",\"type\":\"message\",\"role\":\"assistant\",\"content\":[],\"model\":\"primary-actual\",\"stop_reason\":null,\"stop_sequence\":null,\"usage\":{\"input_tokens\":0,\"output_tokens\":0}}}\n\n",
+    "event: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"text_delta\",\"text\":\"Usage text.\"}}\n\n",
+    "event: message_delta\ndata: {\"type\":\"message_delta\",\"delta\":{\"stop_reason\":\"end_turn\",\"stop_sequence\":null},\"usage\":{\"input_tokens\":7,\"output_tokens\":2}}\n\n",
+    "event: message_stop\ndata: {\"type\":\"message_stop\"}\n\n"
+  ],
+  "required_events": [
+    "response.created",
+    "response.output_item.added",
+    "response.content_part.added",
+    "response.output_text.delta",
+    "response.output_text.done",
+    "response.content_part.done",
+    "response.output_item.done",
+    "response.completed"
+  ],
+  "expected": {
+    "status": "completed",
+    "item_types": [
+      "message"
+    ],
+    "texts": [
+      "Usage text."
+    ],
+    "call_ids": [],
+    "usage": {
+      "input_tokens": 7,
+      "output_tokens": 2,
+      "total_tokens": 9
+    }
+  },
+  "forbidden_fragments": [
+    "event: content_block_",
+    "\"type\":\"message_delta\"",
+    "\"event_kind\":\"tool_intent\""
+  ]
+}

--- a/crates/gateway/tests/fixtures/openai_responses/codex-supported-controls.json
+++ b/crates/gateway/tests/fixtures/openai_responses/codex-supported-controls.json
@@ -1,0 +1,72 @@
+{
+  "request": {
+    "model": "gateway-default",
+    "input": [
+      {
+        "type": "message",
+        "role": "user",
+        "content": [
+          {
+            "type": "input_text",
+            "text": "Describe this image"
+          },
+          {
+            "type": "input_image",
+            "image_url": "https://example.com/image.png",
+            "detail": "high"
+          }
+        ]
+      }
+    ],
+    "stream": false,
+    "parallel_tool_calls": false,
+    "reasoning": {
+      "effort": "low",
+      "summary": "concise"
+    },
+    "include": [
+      "reasoning.encrypted_content"
+    ],
+    "text": {
+      "format": {
+        "type": "text"
+      },
+      "verbosity": "low"
+    },
+    "tools": [
+      {
+        "type": "function",
+        "function": {
+          "name": "lookup",
+          "description": "Look something up",
+          "parameters": {
+            "type": "object",
+            "properties": {
+              "query": {
+                "type": "string"
+              }
+            },
+            "required": [
+              "query"
+            ]
+          }
+        }
+      },
+      {
+        "type": "function",
+        "function": {
+          "name": "ignored",
+          "parameters": {
+            "type": "object"
+          }
+        }
+      }
+    ],
+    "tool_choice": {
+      "type": "function",
+      "function": {
+        "name": "lookup"
+      }
+    }
+  }
+}

--- a/crates/gateway/tests/fixtures/openai_responses/codex-sync-mixed.json
+++ b/crates/gateway/tests/fixtures/openai_responses/codex-sync-mixed.json
@@ -1,0 +1,53 @@
+{
+  "request": {
+    "model": "gateway-default",
+    "input": "hello",
+    "stream": false
+  },
+  "request_model": "gateway-default",
+  "provider_response": {
+    "id": "resp_sync_mixed",
+    "type": "message",
+    "role": "assistant",
+    "content": [
+      {
+        "type": "text",
+        "text": "Before tool"
+      },
+      {
+        "type": "tool_use",
+        "id": "call_fixture_mixed",
+        "name": "lookup",
+        "input": {
+          "path": "Cargo.toml"
+        }
+      },
+      {
+        "type": "text",
+        "text": "After tool"
+      }
+    ],
+    "model": "primary-actual",
+    "stop_reason": "tool_use",
+    "stop_sequence": null,
+    "usage": {
+      "input_tokens": 8,
+      "output_tokens": 5
+    }
+  },
+  "expected": {
+    "status": "completed",
+    "item_types": [
+      "message",
+      "function_call",
+      "message"
+    ],
+    "texts": ["Before tool", "After tool"],
+    "call_ids": ["call_fixture_mixed"],
+    "usage": {
+      "input_tokens": 8,
+      "output_tokens": 5,
+      "total_tokens": 13
+    }
+  }
+}

--- a/crates/gateway/tests/fixtures/openai_responses/codex-sync-text.json
+++ b/crates/gateway/tests/fixtures/openai_responses/codex-sync-text.json
@@ -1,0 +1,40 @@
+{
+  "request": {
+    "model": "gateway-default",
+    "input": "hello",
+    "stream": false,
+    "ignored_top_level": "ignored"
+  },
+  "request_model": "gateway-default",
+  "provider_response": {
+    "id": "resp_sync_text",
+    "type": "message",
+    "role": "assistant",
+    "content": [
+      {
+        "type": "text",
+        "text": "Hello from text"
+      }
+    ],
+    "model": "primary-actual",
+    "stop_reason": "end_turn",
+    "stop_sequence": null,
+    "usage": {
+      "input_tokens": 5,
+      "output_tokens": 2
+    }
+  },
+  "expected": {
+    "status": "completed",
+    "item_types": [
+      "message"
+    ],
+    "texts": ["Hello from text"],
+    "call_ids": [],
+    "usage": {
+      "input_tokens": 5,
+      "output_tokens": 2,
+      "total_tokens": 7
+    }
+  }
+}

--- a/crates/gateway/tests/fixtures/openai_responses/codex-sync-tool-call.json
+++ b/crates/gateway/tests/fixtures/openai_responses/codex-sync-tool-call.json
@@ -1,0 +1,43 @@
+{
+  "request": {
+    "model": "gateway-default",
+    "input": "hello",
+    "stream": false
+  },
+  "request_model": "gateway-default",
+  "provider_response": {
+    "id": "resp_sync_tool",
+    "type": "message",
+    "role": "assistant",
+    "content": [
+      {
+        "type": "tool_use",
+        "id": "call_fixture_tool",
+        "name": "lookup",
+        "input": {
+          "path": "README.md"
+        }
+      }
+    ],
+    "model": "primary-actual",
+    "stop_reason": "tool_use",
+    "stop_sequence": null,
+    "usage": {
+      "input_tokens": 6,
+      "output_tokens": 3
+    }
+  },
+  "expected": {
+    "status": "completed",
+    "item_types": [
+      "function_call"
+    ],
+    "texts": [],
+    "call_ids": ["call_fixture_tool"],
+    "usage": {
+      "input_tokens": 6,
+      "output_tokens": 3,
+      "total_tokens": 9
+    }
+  }
+}

--- a/crates/gateway/tests/fixtures/openai_responses/negative-invalid-function-call-arguments.json
+++ b/crates/gateway/tests/fixtures/openai_responses/negative-invalid-function-call-arguments.json
@@ -1,0 +1,17 @@
+{
+  "request": {
+    "model": "gateway-default",
+    "input": [
+      {
+        "type": "function_call",
+        "call_id": "call_bad_args",
+        "name": "lookup",
+        "arguments": "not-json"
+      }
+    ]
+  },
+  "expected_error_contains": "function_call.arguments must be a JSON string",
+  "expected_status": 400,
+  "expected_error_class": "route",
+  "expected_error_message": "Route selection failed"
+}

--- a/crates/gateway/tests/fixtures/openai_responses/negative-orphaned-function-call-output-without-previous-response-id.json
+++ b/crates/gateway/tests/fixtures/openai_responses/negative-orphaned-function-call-output-without-previous-response-id.json
@@ -1,0 +1,16 @@
+{
+  "request": {
+    "model": "gateway-default",
+    "input": [
+      {
+        "type": "function_call_output",
+        "call_id": "call_missing",
+        "output": "{\"ok\":true}"
+      }
+    ]
+  },
+  "expected_error_contains": "function_call_output.call_id must reference a prior function_call item",
+  "expected_status": 400,
+  "expected_error_class": "route",
+  "expected_error_message": "Route selection failed"
+}

--- a/crates/gateway/tests/fixtures/openai_responses/request-previous-response-id-function-call-output.json
+++ b/crates/gateway/tests/fixtures/openai_responses/request-previous-response-id-function-call-output.json
@@ -1,0 +1,16 @@
+{
+  "request": {
+    "model": "gateway-default",
+    "previous_response_id": "resp_prev_fixture_1",
+    "input": [
+      {
+        "type": "function_call_output",
+        "call_id": "call_fixture_1",
+        "output": "{\"ok\":true}"
+      }
+    ]
+  },
+  "previous_response_id": "resp_prev_fixture_1",
+  "expected_tool_use_id": "call_fixture_1",
+  "expected_output": "{\"ok\":true}"
+}

--- a/crates/gateway/tests/fixtures/openai_responses/request-tool-loop-function-call-output.json
+++ b/crates/gateway/tests/fixtures/openai_responses/request-tool-loop-function-call-output.json
@@ -13,6 +13,12 @@
         ]
       },
       {
+        "type": "function_call",
+        "call_id": "call_fixture_1",
+        "name": "lookup",
+        "arguments": "{\"query\":\"x\"}"
+      },
+      {
         "type": "function_call_output",
         "call_id": "call_fixture_1",
         "output": "{\"ok\":true}"
@@ -20,5 +26,9 @@
     ]
   },
   "expected_tool_use_id": "call_fixture_1",
+  "expected_tool_name": "lookup",
+  "expected_arguments": {
+    "query": "x"
+  },
   "expected_output": "{\"ok\":true}"
 }

--- a/crates/gateway/tests/openai_responses_conformance.rs
+++ b/crates/gateway/tests/openai_responses_conformance.rs
@@ -63,6 +63,8 @@ struct NegativeFixture {
 struct ToolLoopFixture {
     request: Value,
     expected_tool_use_id: String,
+    expected_tool_name: String,
+    expected_arguments: Value,
     expected_output: String,
 }
 
@@ -346,6 +348,19 @@ async fn tool_loop_continuation_preserves_call_id_through_the_public_route() {
 
     let requests = captured_requests.lock().unwrap();
     assert_eq!(requests.len(), 1);
+    let tool_use_message = &requests[0].messages[1];
+    let tool_use_blocks = match &tool_use_message.content {
+        substrate_gateway::models::MessageContent::Blocks(blocks) => blocks,
+        other => panic!("expected tool use blocks, got {other:?}"),
+    };
+    assert!(matches!(
+        &tool_use_blocks[0],
+        substrate_gateway::models::ContentBlock::Known(
+            substrate_gateway::models::KnownContentBlock::ToolUse { id, name, input }
+        ) if id == &fixture.expected_tool_use_id
+            && name == &fixture.expected_tool_name
+            && input == &fixture.expected_arguments
+    ));
     let last_message = requests[0].messages.last().expect("captured request");
     let blocks = match &last_message.content {
         substrate_gateway::models::MessageContent::Blocks(blocks) => blocks,
@@ -392,8 +407,8 @@ async fn tool_loop_continuation_uses_upstream_responses_api_and_preserves_functi
                 {
                     "type": "function_call",
                     "call_id": fixture.expected_tool_use_id,
-                    "name": "tool_call",
-                    "arguments": "{}"
+                    "name": fixture.expected_tool_name,
+                    "arguments": fixture.expected_arguments.to_string()
                 },
                 {
                     "type": "function_call_output",
@@ -451,6 +466,42 @@ async fn tool_loop_continuation_uses_upstream_responses_api_and_preserves_functi
     assert!(call_ids.is_empty());
 
     responses_mock.assert_async().await;
+}
+
+#[tokio::test]
+async fn orphaned_function_call_output_rejects_before_any_upstream_call() {
+    let mut server = Server::new_async().await;
+    let responses_mock = server
+        .mock("POST", "/v1/responses")
+        .with_status(200)
+        .with_body(responses_api_sync_body("gpt-4.1-mini", "wrong"))
+        .create_async()
+        .await;
+
+    let harness = build_openai_provider_harness(&server.url(), "gpt-4.1-mini");
+    let request = json!({
+        "model": "gateway-default",
+        "input": [
+            {
+                "type": "function_call_output",
+                "call_id": "call_missing",
+                "output": "{\"ok\":true}"
+            }
+        ]
+    });
+    let response = harness.invoke_responses(HeaderMap::new(), request).await;
+
+    assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+    assert!(
+        !responses_mock.matched_async().await,
+        "gateway must reject orphaned continuations before the upstream call"
+    );
+
+    let body = response_body_text(response).await;
+    let json: Value = serde_json::from_str(&body).expect("negative response body must be JSON");
+    assert_eq!(json["error"]["type"], "error");
+    assert_eq!(json["error"]["class"], "route");
+    assert_eq!(json["error"]["message"], "Route selection failed");
 }
 
 #[tokio::test]
@@ -718,6 +769,7 @@ async fn generic_negative_responses_requests_return_redacted_gateway_envelopes()
         "codex-negative-non-function-tool.json",
         "codex-negative-unsupported-text-format.json",
         "codex-negative-invalid-call-id.json",
+        "codex-negative-invalid-function-call-arguments.json",
     ] {
         let fixture: NegativeFixture =
             read_json_fixture(FixtureNamespace::OpenAiResponses, fixture_name);
@@ -774,6 +826,7 @@ async fn codex_route_negative_requests_return_redacted_gateway_envelopes() {
         "codex-negative-required-tool-choice.json",
         "codex-negative-invalid-reasoning-summary.json",
         "codex-negative-encrypted-include-without-reasoning.json",
+        "codex-negative-invalid-function-call-arguments.json",
     ] {
         let fixture: NegativeFixture =
             read_json_fixture(FixtureNamespace::OpenAiResponses, fixture_name);

--- a/crates/gateway/tests/openai_responses_conformance.rs
+++ b/crates/gateway/tests/openai_responses_conformance.rs
@@ -188,7 +188,11 @@ fn responses_api_sync_body(model: &str, text: &str) -> String {
 
 #[tokio::test]
 async fn sync_responses_conformance_cases_cover_shape_order_and_ignore_posture() {
-    for fixture_name in ["sync-text.json", "sync-tool-call.json", "sync-mixed.json"] {
+    for fixture_name in [
+        "codex-sync-text.json",
+        "codex-sync-tool-call.json",
+        "codex-sync-mixed.json",
+    ] {
         let fixture: SyncFixture =
             read_json_fixture(FixtureNamespace::OpenAiResponses, fixture_name);
         let harness = build_sync_harness(&fixture.provider_response);
@@ -271,7 +275,7 @@ async fn sync_responses_conformance_keeps_reasoning_internal() {
 async fn tool_loop_continuation_preserves_call_id_through_the_public_route() {
     let fixture: ToolLoopFixture = read_json_fixture(
         FixtureNamespace::OpenAiResponses,
-        "request-tool-loop-function-call-output.json",
+        "codex-request-tool-loop-function-call-output.json",
     );
     let provider = StubProvider::new(
         substrate_gateway::server::openai_conformance_test_support::response_text_response(
@@ -318,7 +322,7 @@ async fn tool_loop_continuation_uses_upstream_responses_api_and_preserves_functi
 ) {
     let fixture: ToolLoopFixture = read_json_fixture(
         FixtureNamespace::OpenAiResponses,
-        "request-tool-loop-function-call-output.json",
+        "codex-request-tool-loop-function-call-output.json",
     );
     let mut server = Server::new_async().await;
     let responses_mock = server
@@ -489,10 +493,10 @@ async fn explicit_tool_choice_is_preserved_in_metadata_and_flat_tools() {
 #[tokio::test]
 async fn streaming_responses_conformance_cases_cover_event_order_and_completed_payload() {
     for fixture_name in [
-        "stream-text.json",
-        "stream-tool-call.json",
-        "stream-mixed.json",
-        "stream-with-usage.json",
+        "codex-stream-text.json",
+        "codex-stream-tool-call.json",
+        "codex-stream-mixed.json",
+        "codex-stream-with-usage.json",
     ] {
         let fixture: StreamFixture =
             read_json_fixture(FixtureNamespace::OpenAiResponses, fixture_name);
@@ -563,10 +567,10 @@ async fn streaming_responses_conformance_cases_cover_event_order_and_completed_p
 #[tokio::test]
 async fn negative_responses_requests_return_redacted_gateway_envelopes() {
     for fixture_name in [
-        "negative-built-in-tool.json",
-        "negative-non-function-tool.json",
-        "negative-unsupported-text-format.json",
-        "negative-invalid-call-id.json",
+        "codex-negative-built-in-tool.json",
+        "codex-negative-non-function-tool.json",
+        "codex-negative-unsupported-text-format.json",
+        "codex-negative-invalid-call-id.json",
     ] {
         let fixture: NegativeFixture =
             read_json_fixture(FixtureNamespace::OpenAiResponses, fixture_name);

--- a/crates/gateway/tests/openai_responses_conformance.rs
+++ b/crates/gateway/tests/openai_responses_conformance.rs
@@ -11,6 +11,8 @@ use substrate_gateway::server::openai_conformance_test_support::{
     StubProvider,
 };
 
+const OPENAI_RESPONSES_TOOL_CHOICE_METADATA_KEY: &str = "openai_responses_tool_choice";
+
 #[derive(Debug, Deserialize)]
 struct UsageExpected {
     input_tokens: u32,
@@ -388,6 +390,56 @@ async fn parallel_tool_calls_is_preserved_on_the_public_responses_route() {
             .as_ref()
             .and_then(|metadata| metadata.get("parallel_tool_calls")),
         Some(&serde_json::json!(false))
+    );
+}
+
+#[tokio::test]
+async fn explicit_tool_choice_is_preserved_in_metadata_and_flat_tools() {
+    let provider = StubProvider::new(
+        substrate_gateway::server::openai_conformance_test_support::response_text_response(
+            "tool-choice-ok",
+            "primary-actual",
+        ),
+        vec![],
+    );
+    let harness = ConformanceHarness::single_provider(provider, "primary-actual", false);
+
+    let request = serde_json::json!({
+        "model": "gateway-default",
+        "input": "hello",
+        "stream": false,
+        "tools": [
+            { "type": "function", "function": { "name": "alpha", "parameters": {"type":"object"} } },
+            { "type": "function", "function": { "name": "beta", "parameters": {"type":"object"} } }
+        ],
+        "tool_choice": { "type": "function", "function": { "name": "beta" } }
+    });
+
+    let response = harness.invoke_responses(HeaderMap::new(), request).await;
+    assert_eq!(response.status(), StatusCode::OK);
+
+    let captured_requests = harness.captured_requests();
+    let captured_requests = captured_requests.lock().unwrap();
+    assert_eq!(captured_requests.len(), 1);
+    let captured = &captured_requests[0];
+
+    assert_eq!(
+        captured
+            .metadata
+            .as_ref()
+            .and_then(|metadata| metadata.get(OPENAI_RESPONSES_TOOL_CHOICE_METADATA_KEY)),
+        Some(&serde_json::json!({
+            "type": "function",
+            "function": { "name": "beta" }
+        }))
+    );
+    assert_eq!(captured.tools.as_ref().map(|tools| tools.len()), Some(1));
+    assert_eq!(
+        captured
+            .tools
+            .as_ref()
+            .and_then(|tools| tools[0].name.as_deref()),
+        Some("beta")
     );
 }
 

--- a/crates/gateway/tests/openai_responses_conformance.rs
+++ b/crates/gateway/tests/openai_responses_conformance.rs
@@ -225,6 +225,49 @@ async fn sync_responses_conformance_cases_cover_shape_order_and_ignore_posture()
 }
 
 #[tokio::test]
+async fn sync_responses_conformance_keeps_reasoning_internal() {
+    let provider_response = GatewayResponse {
+        id: "resp_reasoning_internal".to_string(),
+        r#type: "message".to_string(),
+        role: "assistant".to_string(),
+        content: vec![
+            substrate_gateway::models::ContentBlock::thinking(serde_json::json!({
+                "thinking": "secret reasoning"
+            })),
+            substrate_gateway::models::ContentBlock::text("Visible answer".to_string(), None),
+        ],
+        model: "primary-actual".to_string(),
+        stop_reason: Some("end_turn".to_string()),
+        stop_sequence: None,
+        usage: substrate_gateway::core::GatewayUsage {
+            input_tokens: 3,
+            output_tokens: 2,
+            cache_creation_input_tokens: None,
+            cache_read_input_tokens: None,
+        },
+    };
+
+    let harness = build_sync_harness(&provider_response);
+    let request = json!({
+        "model": "gateway-default",
+        "input": "hello",
+        "stream": false
+    });
+    let response = harness.invoke_responses(HeaderMap::new(), request).await;
+
+    assert_eq!(response.status(), StatusCode::OK);
+    let body = response_body_text(response).await;
+    assert!(!body.contains("secret reasoning"));
+    assert!(body.contains("Visible answer"));
+
+    let json: Value = serde_json::from_str(&body).expect("sync response body must be JSON");
+    let (item_types, texts, call_ids) = collect_output_summary(&json["output"]);
+    assert_eq!(item_types, vec!["message"]);
+    assert_eq!(texts, vec!["Visible answer"]);
+    assert!(call_ids.is_empty());
+}
+
+#[tokio::test]
 async fn tool_loop_continuation_preserves_call_id_through_the_public_route() {
     let fixture: ToolLoopFixture = read_json_fixture(
         FixtureNamespace::OpenAiResponses,

--- a/crates/gateway/tests/openai_responses_conformance.rs
+++ b/crates/gateway/tests/openai_responses_conformance.rs
@@ -2,6 +2,7 @@ use axum::http::{HeaderMap, StatusCode};
 use mockito::{Matcher, Server};
 use serde::Deserialize;
 use serde_json::{json, Value};
+use substrate_gateway::auth::TokenStore;
 use substrate_gateway::cli::ModelMapping;
 use substrate_gateway::core::GatewayResponse;
 use substrate_gateway::providers::streaming::parse_sse_events;
@@ -12,6 +13,10 @@ use substrate_gateway::server::openai_conformance_test_support::{
 };
 
 const OPENAI_RESPONSES_TOOL_CHOICE_METADATA_KEY: &str = "openai_responses_tool_choice";
+const OPENAI_RESPONSES_REASONING_EFFORT_METADATA_KEY: &str = "openai_responses_reasoning_effort";
+const OPENAI_RESPONSES_REASONING_SUMMARY_METADATA_KEY: &str = "openai_responses_reasoning_summary";
+const OPENAI_RESPONSES_INCLUDE_METADATA_KEY: &str = "openai_responses_include";
+const OPENAI_RESPONSES_TEXT_VERBOSITY_METADATA_KEY: &str = "openai_responses_text_verbosity";
 
 #[derive(Debug, Deserialize)]
 struct UsageExpected {
@@ -59,6 +64,11 @@ struct ToolLoopFixture {
     request: Value,
     expected_tool_use_id: String,
     expected_output: String,
+}
+
+#[derive(Debug, Deserialize)]
+struct SupportedControlsFixture {
+    request: Value,
 }
 
 fn collect_output_summary(output: &Value) -> (Vec<String>, Vec<String>, Vec<String>) {
@@ -152,6 +162,43 @@ fn build_openai_provider_harness(base_url: &str, actual_model: &str) -> Conforma
         vec![ModelMapping {
             priority: 1,
             provider: "openai".to_string(),
+            actual_model: actual_model.to_string(),
+            inject_continuation_prompt: false,
+        }],
+    )
+}
+
+fn build_codex_oauth_provider_harness(actual_model: &str) -> ConformanceHarness {
+    let token_store = TokenStore::new(std::env::temp_dir().join(format!(
+        "substrate-gateway-codex-conformance-{}.json",
+        uuid::Uuid::new_v4()
+    )))
+    .unwrap();
+    let registry = ProviderRegistry::from_configs_with_models(
+        &[ProviderConfig {
+            name: "openai-codex".to_string(),
+            provider_type: "openai".to_string(),
+            auth_type: AuthType::OAuth,
+            api_key: None,
+            oauth_provider: Some("test-oauth-provider".to_string()),
+            project_id: None,
+            location: None,
+            base_url: Some("https://chatgpt.com/backend-api".to_string()),
+            headers: None,
+            models: vec![],
+            enabled: Some(true),
+        }],
+        Some(token_store),
+        &[],
+    )
+    .unwrap();
+
+    ConformanceHarness::with_registry(
+        "gateway-default",
+        registry,
+        vec![ModelMapping {
+            priority: 1,
+            provider: "openai-codex".to_string(),
             actual_model: actual_model.to_string(),
             inject_continuation_prompt: false,
         }],
@@ -441,6 +488,106 @@ async fn parallel_tool_calls_is_preserved_on_the_public_responses_route() {
 }
 
 #[tokio::test]
+async fn supported_route_matrix_controls_are_preserved_in_gateway_request_shape() {
+    let fixture: SupportedControlsFixture = read_json_fixture(
+        FixtureNamespace::OpenAiResponses,
+        "codex-supported-controls.json",
+    );
+    let provider = StubProvider::new(
+        substrate_gateway::server::openai_conformance_test_support::response_text_response(
+            "matrix-ok",
+            "primary-actual",
+        ),
+        vec![],
+    );
+    let harness = ConformanceHarness::single_provider(provider, "primary-actual", false);
+
+    let response = harness
+        .invoke_responses(HeaderMap::new(), fixture.request.clone())
+        .await;
+
+    assert_eq!(response.status(), StatusCode::OK);
+
+    let captured_requests = harness.captured_requests();
+    let captured_requests = captured_requests.lock().unwrap();
+    assert_eq!(captured_requests.len(), 1);
+
+    let captured = &captured_requests[0];
+    assert_eq!(captured.stream, Some(false));
+    assert_eq!(
+        captured
+            .metadata
+            .as_ref()
+            .and_then(|metadata| metadata.get("parallel_tool_calls")),
+        Some(&serde_json::json!(false))
+    );
+    assert_eq!(
+        captured
+            .metadata
+            .as_ref()
+            .and_then(|metadata| metadata.get(OPENAI_RESPONSES_REASONING_EFFORT_METADATA_KEY)),
+        Some(&serde_json::json!("low"))
+    );
+    assert_eq!(
+        captured
+            .metadata
+            .as_ref()
+            .and_then(|metadata| metadata.get(OPENAI_RESPONSES_REASONING_SUMMARY_METADATA_KEY)),
+        Some(&serde_json::json!("concise"))
+    );
+    assert_eq!(
+        captured
+            .metadata
+            .as_ref()
+            .and_then(|metadata| metadata.get(OPENAI_RESPONSES_INCLUDE_METADATA_KEY)),
+        Some(&serde_json::json!(["reasoning.encrypted_content"]))
+    );
+    assert_eq!(
+        captured
+            .metadata
+            .as_ref()
+            .and_then(|metadata| metadata.get(OPENAI_RESPONSES_TEXT_VERBOSITY_METADATA_KEY)),
+        Some(&serde_json::json!("low"))
+    );
+    assert_eq!(
+        captured
+            .metadata
+            .as_ref()
+            .and_then(|metadata| metadata.get(OPENAI_RESPONSES_TOOL_CHOICE_METADATA_KEY)),
+        Some(&serde_json::json!({
+            "type": "function",
+            "function": { "name": "lookup" }
+        }))
+    );
+    assert_eq!(captured.tools.as_ref().map(|tools| tools.len()), Some(1));
+    assert_eq!(
+        captured
+            .tools
+            .as_ref()
+            .and_then(|tools| tools[0].name.as_deref()),
+        Some("lookup")
+    );
+
+    assert_eq!(captured.messages.len(), 1);
+    let blocks = match &captured.messages[0].content {
+        substrate_gateway::models::MessageContent::Blocks(blocks) => blocks,
+        other => panic!("expected multimodal blocks, got {other:?}"),
+    };
+    assert!(matches!(
+        &blocks[0],
+        substrate_gateway::models::ContentBlock::Known(
+            substrate_gateway::models::KnownContentBlock::Text { text, .. }
+        ) if text == "Describe this image"
+    ));
+    assert!(matches!(
+        &blocks[1],
+        substrate_gateway::models::ContentBlock::Known(
+            substrate_gateway::models::KnownContentBlock::Image { source }
+        ) if source.url.as_deref() == Some("https://example.com/image.png")
+    ));
+}
+
+#[tokio::test]
 async fn explicit_tool_choice_is_preserved_in_metadata_and_flat_tools() {
     let provider = StubProvider::new(
         substrate_gateway::server::openai_conformance_test_support::response_text_response(
@@ -565,7 +712,7 @@ async fn streaming_responses_conformance_cases_cover_event_order_and_completed_p
 }
 
 #[tokio::test]
-async fn negative_responses_requests_return_redacted_gateway_envelopes() {
+async fn generic_negative_responses_requests_return_redacted_gateway_envelopes() {
     for fixture_name in [
         "codex-negative-built-in-tool.json",
         "codex-negative-non-function-tool.json",
@@ -582,6 +729,55 @@ async fn negative_responses_requests_return_redacted_gateway_envelopes() {
             vec![],
         );
         let harness = ConformanceHarness::single_provider(provider, "primary-actual", false);
+
+        let response = harness
+            .invoke_responses(HeaderMap::new(), fixture.request.clone())
+            .await;
+
+        assert_eq!(
+            response.status(),
+            StatusCode::from_u16(fixture.expected_status).unwrap(),
+            "{fixture_name}"
+        );
+
+        let body = response_body_text(response).await;
+        assert!(
+            !body.contains(&fixture.expected_error_contains),
+            "{fixture_name}: public error body should stay redacted"
+        );
+        let json: Value = serde_json::from_str(&body).expect("negative response body must be JSON");
+
+        assert_eq!(json["error"]["type"], "error", "{fixture_name}");
+        assert_eq!(
+            json["error"]["class"], fixture.expected_error_class,
+            "{fixture_name}"
+        );
+        assert_eq!(
+            json["error"]["message"], fixture.expected_error_message,
+            "{fixture_name}"
+        );
+    }
+}
+
+#[tokio::test]
+async fn codex_route_negative_requests_return_redacted_gateway_envelopes() {
+    for fixture_name in [
+        "codex-negative-max-output-tokens.json",
+        "codex-negative-metadata.json",
+        "codex-negative-truncation.json",
+        "codex-negative-previous-response-id.json",
+        "codex-negative-temperature.json",
+        "codex-negative-top-p.json",
+        "codex-negative-user.json",
+        "codex-negative-service-tier.json",
+        "codex-negative-stream-options.json",
+        "codex-negative-required-tool-choice.json",
+        "codex-negative-invalid-reasoning-summary.json",
+        "codex-negative-encrypted-include-without-reasoning.json",
+    ] {
+        let fixture: NegativeFixture =
+            read_json_fixture(FixtureNamespace::OpenAiResponses, fixture_name);
+        let harness = build_codex_oauth_provider_harness("codex-mini-latest");
 
         let response = harness
             .invoke_responses(HeaderMap::new(), fixture.request.clone())

--- a/crates/gateway/tests/openai_responses_conformance.rs
+++ b/crates/gateway/tests/openai_responses_conformance.rs
@@ -69,6 +69,14 @@ struct ToolLoopFixture {
 }
 
 #[derive(Debug, Deserialize)]
+struct PreviousResponseContinuationFixture {
+    request: Value,
+    previous_response_id: String,
+    expected_tool_use_id: String,
+    expected_output: String,
+}
+
+#[derive(Debug, Deserialize)]
 struct SupportedControlsFixture {
     request: Value,
 }
@@ -469,7 +477,88 @@ async fn tool_loop_continuation_uses_upstream_responses_api_and_preserves_functi
 }
 
 #[tokio::test]
+async fn previous_response_id_continuation_uses_upstream_responses_api_without_replaying_function_call(
+) {
+    let fixture: PreviousResponseContinuationFixture = read_json_fixture(
+        FixtureNamespace::OpenAiResponses,
+        "request-previous-response-id-function-call-output.json",
+    );
+    let mut server = Server::new_async().await;
+    let responses_mock = server
+        .mock("POST", "/v1/responses")
+        .match_header("authorization", "Bearer openai-secret")
+        .match_body(Matcher::PartialJson(json!({
+            "model": "gpt-4.1-mini",
+            "stream": true,
+            "previous_response_id": fixture.previous_response_id,
+            "input": [
+                {
+                    "type": "function_call_output",
+                    "call_id": fixture.expected_tool_use_id,
+                    "output": fixture.expected_output
+                }
+            ]
+        })))
+        .with_status(200)
+        .with_body(responses_api_sync_body(
+            "gpt-4.1-mini",
+            "continued-tool-loop-ok",
+        ))
+        .create_async()
+        .await;
+    let chat_mock = server
+        .mock("POST", "/v1/chat/completions")
+        .with_status(200)
+        .with_body(
+            r#"{
+            "id":"chatcmpl_wrong_endpoint",
+            "object":"chat.completion",
+            "model":"gpt-4.1-mini",
+            "choices":[{
+                "message":{"role":"assistant","content":"wrong endpoint"},
+                "finish_reason":"stop"
+            }],
+            "usage":{"prompt_tokens":1,"completion_tokens":1,"total_tokens":2}
+        }"#,
+        )
+        .create_async()
+        .await;
+
+    let harness = build_openai_provider_harness(&server.url(), "gpt-4.1-mini");
+    let response = harness
+        .invoke_responses(HeaderMap::new(), fixture.request.clone())
+        .await;
+
+    assert!(
+        responses_mock.matched_async().await,
+        "gateway should forward previous_response_id continuations to /v1/responses with output-only function_call_output items"
+    );
+    assert!(
+        !chat_mock.matched_async().await,
+        "gateway must not lower previous_response_id continuations into /v1/chat/completions"
+    );
+    let status = response.status();
+    let body = response_body_text(response).await;
+    assert_eq!(status, StatusCode::OK, "{body}");
+    let json: Value =
+        serde_json::from_str(&body).expect("continuation regression response body must be JSON");
+    assert_eq!(json["object"], "response");
+    assert_eq!(json["status"], "completed");
+
+    let (item_types, texts, call_ids) = collect_output_summary(&json["output"]);
+    assert_eq!(item_types, vec!["message".to_string()]);
+    assert_eq!(texts, vec!["continued-tool-loop-ok".to_string()]);
+    assert!(call_ids.is_empty());
+
+    responses_mock.assert_async().await;
+}
+
+#[tokio::test]
 async fn orphaned_function_call_output_rejects_before_any_upstream_call() {
+    let fixture: NegativeFixture = read_json_fixture(
+        FixtureNamespace::OpenAiResponses,
+        "negative-orphaned-function-call-output-without-previous-response-id.json",
+    );
     let mut server = Server::new_async().await;
     let responses_mock = server
         .mock("POST", "/v1/responses")
@@ -479,29 +568,28 @@ async fn orphaned_function_call_output_rejects_before_any_upstream_call() {
         .await;
 
     let harness = build_openai_provider_harness(&server.url(), "gpt-4.1-mini");
-    let request = json!({
-        "model": "gateway-default",
-        "input": [
-            {
-                "type": "function_call_output",
-                "call_id": "call_missing",
-                "output": "{\"ok\":true}"
-            }
-        ]
-    });
-    let response = harness.invoke_responses(HeaderMap::new(), request).await;
+    let response = harness
+        .invoke_responses(HeaderMap::new(), fixture.request.clone())
+        .await;
 
-    assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+    assert_eq!(
+        response.status(),
+        StatusCode::from_u16(fixture.expected_status).unwrap()
+    );
     assert!(
         !responses_mock.matched_async().await,
-        "gateway must reject orphaned continuations before the upstream call"
+        "gateway must reject orphaned continuations before the upstream call when previous_response_id is absent"
+    );
+    assert!(
+        fixture.request.get("previous_response_id").is_none(),
+        "negative orphan fixture must not include previous_response_id"
     );
 
     let body = response_body_text(response).await;
     let json: Value = serde_json::from_str(&body).expect("negative response body must be JSON");
     assert_eq!(json["error"]["type"], "error");
-    assert_eq!(json["error"]["class"], "route");
-    assert_eq!(json["error"]["message"], "Route selection failed");
+    assert_eq!(json["error"]["class"], fixture.expected_error_class);
+    assert_eq!(json["error"]["message"], fixture.expected_error_message);
 }
 
 #[tokio::test]

--- a/crates/gateway/tests/openai_shared_parity.rs
+++ b/crates/gateway/tests/openai_shared_parity.rs
@@ -1,7 +1,17 @@
 use async_trait::async_trait;
 use axum::http::{HeaderMap, HeaderValue, StatusCode};
+use base64::engine::general_purpose::URL_SAFE_NO_PAD;
+use base64::Engine as _;
+use mockito::Server;
+use once_cell::sync::Lazy;
+use secrecy::ExposeSecret;
 use serde::Deserialize;
 use serde_json::{json, Value};
+use std::env;
+use std::fs;
+use std::sync::Mutex;
+use tempfile::TempDir;
+use substrate_gateway::auth::CodexAuthState;
 use substrate_gateway::core::{
     GatewayRequest, GatewayResponse, GatewayStreamResponse, GatewayUsage,
 };
@@ -9,12 +19,19 @@ use substrate_gateway::models::{ContentBlock, MessageContent};
 use substrate_gateway::providers::error::ProviderError;
 use substrate_gateway::providers::{GatewayProvider, ProviderRegistry};
 use substrate_gateway::server::openai_conformance_test_support::{
-    read_json_fixture, response_text, ConformanceHarness, FixtureNamespace, StubProvider,
+    read_json_fixture, response_text, response_text_response, ConformanceHarness,
+    FixtureNamespace, StubProvider,
 };
 
 const OPENAI_RESPONSES_TOOL_CHOICE_METADATA_KEY: &str = "openai_responses_tool_choice";
+const SUBSTRATE_LLM_BACKEND_AUTH_CLI_CODEX_ACCOUNT_ID: &str =
+    "SUBSTRATE_LLM_BACKEND_AUTH_CLI_CODEX_ACCOUNT_ID";
+const SUBSTRATE_LLM_BACKEND_AUTH_CLI_CODEX_ACCESS_TOKEN: &str =
+    "SUBSTRATE_LLM_BACKEND_AUTH_CLI_CODEX_ACCESS_TOKEN";
 
 type CapturedRequests = std::sync::Arc<std::sync::Mutex<Vec<GatewayRequest>>>;
+
+static ENV_LOCK: Lazy<Mutex<()>> = Lazy::new(|| Mutex::new(()));
 
 #[derive(Debug, Deserialize)]
 struct ChatSyncFixture {
@@ -80,6 +97,25 @@ fn routing_header(provider: &str) -> HeaderMap {
 
 fn build_single_provider_harness(provider: StubProvider) -> ConformanceHarness {
     ConformanceHarness::single_provider(provider, "primary-actual", false)
+}
+
+fn build_codex_oauth_provider_harness(base_url: &str, actual_model: &str) -> ConformanceHarness {
+    let provider = CodexAuthProbeProvider {
+        base_url: base_url.to_string(),
+        actual_model: actual_model.to_string(),
+    };
+    let mut registry = ProviderRegistry::new();
+    registry.insert_provider_for_tests("codex-auth-probe", Box::new(provider));
+    ConformanceHarness::with_registry(
+        "gateway-default",
+        registry,
+        vec![substrate_gateway::cli::ModelMapping {
+            priority: 1,
+            provider: "codex-auth-probe".to_string(),
+            actual_model: actual_model.to_string(),
+            inject_continuation_prompt: false,
+        }],
+    )
 }
 
 fn build_multi_provider_harness(
@@ -197,6 +233,159 @@ fn assert_provider_error_shape(json: &Value, class: &str, message: &str) {
     assert_eq!(json["error"]["type"], "error");
     assert_eq!(json["error"]["class"], class);
     assert_eq!(json["error"]["message"], message);
+}
+
+fn codex_sync_sse_body(text: &str) -> String {
+    format!(
+        "event: response.completed\ndata: {}\n\n",
+        json!({
+            "type": "response.completed",
+            "response": {
+                "id": "resp_codex_auth",
+                "model": "gpt-5-codex",
+                "output": [
+                    {
+                        "type": "message",
+                        "content": [
+                            {
+                                "type": "output_text",
+                                "text": text
+                            }
+                        ]
+                    }
+                ],
+                "usage": {
+                    "input_tokens": 4,
+                    "output_tokens": 2
+                }
+            }
+        })
+    )
+}
+
+fn codex_access_token(account_id: &str) -> String {
+    let payload = serde_json::json!({
+        "https://api.openai.com/auth": {
+            "chatgpt_account_id": account_id
+        }
+    });
+    let encoded_payload = URL_SAFE_NO_PAD.encode(payload.to_string());
+    format!("header.{}.signature", encoded_payload)
+}
+
+fn write_codex_auth_state(home: &TempDir, account_id: Option<&str>, access_token: &str) {
+    let codex_dir = home.path().join(".codex");
+    fs::create_dir_all(&codex_dir).unwrap();
+    let auth_path = codex_dir.join("auth.json");
+    let payload = match account_id {
+        Some(account_id) => json!({
+            "account_id": account_id,
+            "access_token": access_token
+        }),
+        None => json!({
+            "access_token": access_token
+        }),
+    };
+    fs::write(auth_path, serde_json::to_vec(&payload).unwrap()).unwrap();
+}
+
+struct EnvVarGuard {
+    key: &'static str,
+    original: Option<String>,
+}
+
+impl EnvVarGuard {
+    fn set(key: &'static str, value: impl Into<String>) -> Self {
+        let original = env::var(key).ok();
+        env::set_var(key, value.into());
+        Self { key, original }
+    }
+
+    fn unset(key: &'static str) -> Self {
+        let original = env::var(key).ok();
+        env::remove_var(key);
+        Self { key, original }
+    }
+}
+
+impl Drop for EnvVarGuard {
+    fn drop(&mut self) {
+        match self.original.as_deref() {
+            Some(value) => env::set_var(self.key, value),
+            None => env::remove_var(self.key),
+        }
+    }
+}
+
+#[derive(Debug, Clone)]
+struct CodexAuthProbeProvider {
+    base_url: String,
+    actual_model: String,
+}
+
+#[async_trait]
+impl GatewayProvider for CodexAuthProbeProvider {
+    async fn send_message(
+        &self,
+        _request: GatewayRequest,
+    ) -> Result<GatewayResponse, ProviderError> {
+        let local_auth_path = CodexAuthState::default_path().map_err(|e| {
+            ProviderError::AuthError(format!("Failed to resolve Codex auth path: {}", e))
+        })?;
+        let selection =
+            substrate_gateway::auth::codex_auth_context::CodexAuthSelection::from_env_or_local_auth_state(
+                local_auth_path,
+            )
+            .map_err(|e| ProviderError::AuthError(format!("Failed to load Codex auth state: {}", e)))?;
+        let auth_context = selection.resolve().map_err(|e| {
+            ProviderError::AuthError(format!("Failed to resolve Codex auth context: {}", e))
+        })?;
+
+        let response = reqwest::Client::new()
+            .post(format!("{}/backend-api/codex/responses", self.base_url))
+            .header(
+                "Authorization",
+                format!("Bearer {}", auth_context.access_token.expose_secret()),
+            )
+            .header("ChatGPT-Account-ID", auth_context.account_id)
+            .header("Content-Type", "application/json")
+            .body("{}")
+            .send()
+            .await
+            .map_err(ProviderError::HttpError)?;
+
+        if !response.status().is_success() {
+            let status = response.status().as_u16();
+            let message = response
+                .text()
+                .await
+                .unwrap_or_else(|_| "Unknown error".to_string());
+            return Err(ProviderError::ApiError { status, message });
+        }
+
+        let body = response.text().await.map_err(ProviderError::HttpError)?;
+        Ok(response_text_response(&body, &self.actual_model))
+    }
+
+    async fn send_message_stream(
+        &self,
+        _request: GatewayRequest,
+    ) -> Result<GatewayStreamResponse, ProviderError> {
+        Err(ProviderError::ConfigError(
+            "Codex auth probe provider does not support streaming".to_string(),
+        ))
+    }
+
+    async fn count_tokens(
+        &self,
+        _request: substrate_gateway::models::CountTokensRequest,
+    ) -> Result<substrate_gateway::models::CountTokensResponse, ProviderError> {
+        Ok(substrate_gateway::models::CountTokensResponse { input_tokens: 0 })
+    }
+
+    fn supports_model(&self, model: &str) -> bool {
+        model == self.actual_model
+    }
 }
 
 #[tokio::test]
@@ -757,6 +946,166 @@ async fn provider_auth_failure_maps_to_shared_auth_envelope() {
 
     let json: Value = serde_json::from_str(&body).expect("auth failure response body must be JSON");
     assert_provider_error_shape(&json, "auth", "Authentication failed");
+}
+
+#[tokio::test]
+async fn integrated_codex_env_handoff_succeeds_without_local_auth_files_at_route_boundary() {
+    let _guard = ENV_LOCK.lock().unwrap();
+    let mut server = Server::new_async().await;
+    let access_token = codex_access_token("acct_env_jwt");
+    let upstream = server
+        .mock("POST", "/backend-api/codex/responses")
+        .match_header("authorization", format!("Bearer {}", access_token).as_str())
+        .match_header("chatgpt-account-id", "acct_env_explicit")
+        .match_header("content-type", "application/json")
+        .with_status(200)
+        .with_header("content-type", "text/event-stream")
+        .with_body(codex_sync_sse_body("Integrated auth route proof"))
+        .create_async()
+        .await;
+
+    let bad_home = TempDir::new().unwrap();
+    let bad_home_path = bad_home.path().join("home-as-file");
+    fs::write(&bad_home_path, "not a directory").unwrap();
+
+    let _home = EnvVarGuard::set("HOME", bad_home_path.display().to_string());
+    let _account_id = EnvVarGuard::set(
+        SUBSTRATE_LLM_BACKEND_AUTH_CLI_CODEX_ACCOUNT_ID,
+        "acct_env_explicit",
+    );
+    let _access_token = EnvVarGuard::set(
+        SUBSTRATE_LLM_BACKEND_AUTH_CLI_CODEX_ACCESS_TOKEN,
+        access_token,
+    );
+
+    let harness = build_codex_oauth_provider_harness(&server.url(), "codex-mini-latest");
+    let response = harness
+        .invoke_responses(HeaderMap::new(), responses_sync_request())
+        .await;
+
+    let status = response.status();
+    let body = response_text(response).await;
+    assert_eq!(status, StatusCode::OK, "{body}");
+    assert!(body.contains("Integrated auth route proof"));
+    upstream.assert_async().await;
+}
+
+#[tokio::test]
+async fn standalone_codex_auth_state_succeeds_with_distinct_route_boundary_proof() {
+    let _guard = ENV_LOCK.lock().unwrap();
+    let mut server = Server::new_async().await;
+    let access_token = codex_access_token("acct_local_jwt");
+    let upstream = server
+        .mock("POST", "/backend-api/codex/responses")
+        .match_header("authorization", format!("Bearer {}", access_token).as_str())
+        .match_header("chatgpt-account-id", "acct_local_explicit")
+        .match_header("content-type", "application/json")
+        .with_status(200)
+        .with_header("content-type", "text/event-stream")
+        .with_body(codex_sync_sse_body("Standalone auth route proof"))
+        .create_async()
+        .await;
+
+    let home = TempDir::new().unwrap();
+    write_codex_auth_state(&home, Some("acct_local_explicit"), &access_token);
+
+    let _home = EnvVarGuard::set("HOME", home.path().display().to_string());
+    let _account_id = EnvVarGuard::unset(SUBSTRATE_LLM_BACKEND_AUTH_CLI_CODEX_ACCOUNT_ID);
+    let _access_token = EnvVarGuard::unset(SUBSTRATE_LLM_BACKEND_AUTH_CLI_CODEX_ACCESS_TOKEN);
+
+    let harness = build_codex_oauth_provider_harness(&server.url(), "codex-mini-latest");
+    let response = harness
+        .invoke_responses(HeaderMap::new(), responses_sync_request())
+        .await;
+
+    let status = response.status();
+    let body = response_text(response).await;
+    assert_eq!(status, StatusCode::OK, "{body}");
+    assert!(body.contains("Standalone auth route proof"));
+    upstream.assert_async().await;
+}
+
+#[tokio::test]
+async fn unresolved_codex_identity_fails_before_upstream_for_integrated_and_standalone_modes() {
+    let _guard = ENV_LOCK.lock().unwrap();
+
+    let mut integrated_server = Server::new_async().await;
+    let integrated_upstream = integrated_server
+        .mock("POST", "/backend-api/codex/responses")
+        .expect(0)
+        .with_status(200)
+        .with_header("content-type", "text/event-stream")
+        .with_body(codex_sync_sse_body("should not reach upstream"))
+        .create_async()
+        .await;
+
+    let bad_home = TempDir::new().unwrap();
+    let bad_home_path = bad_home.path().join("home-as-file");
+    fs::write(&bad_home_path, "not a directory").unwrap();
+
+    let _home = EnvVarGuard::set("HOME", bad_home_path.display().to_string());
+    let _account_id = EnvVarGuard::unset(SUBSTRATE_LLM_BACKEND_AUTH_CLI_CODEX_ACCOUNT_ID);
+    let _access_token = EnvVarGuard::set(
+        SUBSTRATE_LLM_BACKEND_AUTH_CLI_CODEX_ACCESS_TOKEN,
+        "not-a-jwt",
+    );
+
+    let integrated_harness =
+        build_codex_oauth_provider_harness(&integrated_server.url(), "gpt-5-codex");
+    let integrated_response = integrated_harness
+        .invoke_responses(HeaderMap::new(), responses_sync_request())
+        .await;
+
+    assert_eq!(integrated_response.status(), StatusCode::BAD_GATEWAY);
+    let integrated_body = response_text(integrated_response).await;
+    assert!(!integrated_body.contains("not-a-jwt"));
+    let integrated_json: Value =
+        serde_json::from_str(&integrated_body).expect("integrated auth failure envelope");
+    assert_provider_error_shape(&integrated_json, "auth", "Authentication failed");
+    integrated_upstream.assert_async().await;
+
+    drop(_access_token);
+    drop(_account_id);
+    drop(_home);
+
+    let mut standalone_server = Server::new_async().await;
+    let standalone_upstream = standalone_server
+        .mock("POST", "/backend-api/codex/responses")
+        .expect(0)
+        .with_status(200)
+        .with_header("content-type", "text/event-stream")
+        .with_body(codex_sync_sse_body("should not reach upstream"))
+        .create_async()
+        .await;
+
+    let standalone_home = TempDir::new().unwrap();
+    write_codex_auth_state(&standalone_home, None, "not-a-jwt");
+
+    let _home = EnvVarGuard::set("HOME", standalone_home.path().display().to_string());
+    let _account_id = EnvVarGuard::unset(SUBSTRATE_LLM_BACKEND_AUTH_CLI_CODEX_ACCOUNT_ID);
+    let _access_token = EnvVarGuard::unset(SUBSTRATE_LLM_BACKEND_AUTH_CLI_CODEX_ACCESS_TOKEN);
+
+    let standalone_harness =
+        build_codex_oauth_provider_harness(&standalone_server.url(), "gpt-5-codex");
+    let standalone_response = standalone_harness
+        .invoke_responses(HeaderMap::new(), responses_sync_request())
+        .await;
+
+    assert_eq!(standalone_response.status(), StatusCode::BAD_GATEWAY);
+    let standalone_body = response_text(standalone_response).await;
+    assert!(!standalone_body.contains("not-a-jwt"));
+    let standalone_json: Value =
+        serde_json::from_str(&standalone_body).expect("standalone auth failure envelope");
+    assert_provider_error_shape(&standalone_json, "auth", "Authentication failed");
+    assert_eq!(
+        integrated_json["error"]["message"],
+        standalone_json["error"]["message"]
+    );
+    assert_eq!(
+        integrated_json["error"]["class"],
+        standalone_json["error"]["class"]
+    );
+    standalone_upstream.assert_async().await;
 }
 
 #[tokio::test]

--- a/crates/gateway/tests/openai_shared_parity.rs
+++ b/crates/gateway/tests/openai_shared_parity.rs
@@ -39,7 +39,7 @@ fn chat_sync_fixture() -> ChatSyncFixture {
 }
 
 fn responses_sync_fixture() -> ResponsesSyncFixture {
-    read_json_fixture(FixtureNamespace::OpenAiResponses, "sync-text.json")
+    read_json_fixture(FixtureNamespace::OpenAiResponses, "codex-sync-text.json")
 }
 
 fn chat_stream_fixture() -> ChatStreamFixture {
@@ -47,7 +47,8 @@ fn chat_stream_fixture() -> ChatStreamFixture {
 }
 
 fn responses_stream_fixture_request() -> Value {
-    read_json_fixture::<Value>(FixtureNamespace::OpenAiResponses, "stream-mixed.json")["request"]
+    read_json_fixture::<Value>(FixtureNamespace::OpenAiResponses, "codex-stream-mixed.json")
+        ["request"]
         .clone()
 }
 

--- a/crates/gateway/tests/openai_shared_parity.rs
+++ b/crates/gateway/tests/openai_shared_parity.rs
@@ -9,8 +9,8 @@ use serde::Deserialize;
 use serde_json::{json, Value};
 use std::env;
 use std::fs;
-use std::sync::Mutex;
-use substrate_gateway::auth::CodexAuthState;
+use std::path::PathBuf;
+use substrate_gateway::auth::CodexAuthSource;
 use substrate_gateway::core::{
     GatewayRequest, GatewayResponse, GatewayStreamResponse, GatewayUsage,
 };
@@ -22,6 +22,7 @@ use substrate_gateway::server::openai_conformance_test_support::{
     StubProvider,
 };
 use tempfile::TempDir;
+use tokio::sync::Mutex;
 
 const OPENAI_RESPONSES_TOOL_CHOICE_METADATA_KEY: &str = "openai_responses_tool_choice";
 const SUBSTRATE_LLM_BACKEND_AUTH_CLI_CODEX_ACCOUNT_ID: &str =
@@ -99,10 +100,15 @@ fn build_single_provider_harness(provider: StubProvider) -> ConformanceHarness {
     ConformanceHarness::single_provider(provider, "primary-actual", false)
 }
 
-fn build_codex_oauth_provider_harness(base_url: &str, actual_model: &str) -> ConformanceHarness {
+fn build_codex_oauth_provider_harness(
+    base_url: &str,
+    actual_model: &str,
+    codex_auth_source: CodexAuthSource,
+) -> ConformanceHarness {
     let provider = CodexAuthProbeProvider {
         base_url: base_url.to_string(),
         actual_model: actual_model.to_string(),
+        codex_auth_source,
     };
     let mut registry = ProviderRegistry::new();
     registry.insert_provider_for_tests("codex-auth-probe", Box::new(provider));
@@ -273,7 +279,7 @@ fn codex_access_token(account_id: &str) -> String {
     format!("header.{}.signature", encoded_payload)
 }
 
-fn write_codex_auth_state(home: &TempDir, account_id: Option<&str>, access_token: &str) {
+fn write_codex_auth_state(home: &TempDir, account_id: Option<&str>, access_token: &str) -> PathBuf {
     let codex_dir = home.path().join(".codex");
     fs::create_dir_all(&codex_dir).unwrap();
     let auth_path = codex_dir.join("auth.json");
@@ -287,6 +293,7 @@ fn write_codex_auth_state(home: &TempDir, account_id: Option<&str>, access_token
         }),
     };
     fs::write(auth_path, serde_json::to_vec(&payload).unwrap()).unwrap();
+    codex_dir.join("auth.json")
 }
 
 struct EnvVarGuard {
@@ -321,6 +328,7 @@ impl Drop for EnvVarGuard {
 struct CodexAuthProbeProvider {
     base_url: String,
     actual_model: String,
+    codex_auth_source: CodexAuthSource,
 }
 
 #[async_trait]
@@ -329,15 +337,7 @@ impl GatewayProvider for CodexAuthProbeProvider {
         &self,
         _request: GatewayRequest,
     ) -> Result<GatewayResponse, ProviderError> {
-        let local_auth_path = CodexAuthState::default_path().map_err(|e| {
-            ProviderError::AuthError(format!("Failed to resolve Codex auth path: {}", e))
-        })?;
-        let selection =
-            substrate_gateway::auth::codex_auth_context::CodexAuthSelection::from_env_or_local_auth_state(
-                local_auth_path,
-            )
-            .map_err(|e| ProviderError::AuthError(format!("Failed to load Codex auth state: {}", e)))?;
-        let auth_context = selection.resolve().map_err(|e| {
+        let auth_context = self.codex_auth_source.resolve().map_err(|e| {
             ProviderError::AuthError(format!("Failed to resolve Codex auth context: {}", e))
         })?;
 
@@ -950,7 +950,7 @@ async fn provider_auth_failure_maps_to_shared_auth_envelope() {
 
 #[tokio::test]
 async fn integrated_codex_env_handoff_succeeds_without_local_auth_files_at_route_boundary() {
-    let _guard = ENV_LOCK.lock().unwrap();
+    let _guard = ENV_LOCK.lock().await;
     let mut server = Server::new_async().await;
     let access_token = codex_access_token("acct_env_jwt");
     let upstream = server
@@ -978,7 +978,11 @@ async fn integrated_codex_env_handoff_succeeds_without_local_auth_files_at_route
         access_token,
     );
 
-    let harness = build_codex_oauth_provider_harness(&server.url(), "codex-mini-latest");
+    let harness = build_codex_oauth_provider_harness(
+        &server.url(),
+        "codex-mini-latest",
+        CodexAuthSource::Integrated,
+    );
     let response = harness
         .invoke_responses(HeaderMap::new(), responses_sync_request())
         .await;
@@ -991,8 +995,52 @@ async fn integrated_codex_env_handoff_succeeds_without_local_auth_files_at_route
 }
 
 #[tokio::test]
+async fn integrated_codex_missing_handoff_does_not_fallback_to_local_auth_files_at_route_boundary()
+{
+    let _guard = ENV_LOCK.lock().await;
+    let mut server = Server::new_async().await;
+    let upstream = server
+        .mock("POST", "/backend-api/codex/responses")
+        .expect(0)
+        .with_status(200)
+        .with_header("content-type", "text/event-stream")
+        .with_body(codex_sync_sse_body("should not reach upstream"))
+        .create_async()
+        .await;
+
+    let standalone_home = TempDir::new().unwrap();
+    let standalone_access_token = codex_access_token("acct_local_jwt");
+    let _auth_path = write_codex_auth_state(
+        &standalone_home,
+        Some("acct_local_explicit"),
+        &standalone_access_token,
+    );
+
+    let _home = EnvVarGuard::set("HOME", standalone_home.path().display().to_string());
+    let _account_id = EnvVarGuard::unset(SUBSTRATE_LLM_BACKEND_AUTH_CLI_CODEX_ACCOUNT_ID);
+    let _access_token = EnvVarGuard::unset(SUBSTRATE_LLM_BACKEND_AUTH_CLI_CODEX_ACCESS_TOKEN);
+
+    let harness = build_codex_oauth_provider_harness(
+        &server.url(),
+        "codex-mini-latest",
+        CodexAuthSource::Integrated,
+    );
+    let response = harness
+        .invoke_responses(HeaderMap::new(), responses_sync_request())
+        .await;
+
+    assert_eq!(response.status(), StatusCode::BAD_GATEWAY);
+    let body = response_text(response).await;
+    assert!(!body.contains("acct_local_explicit"));
+    let json: Value =
+        serde_json::from_str(&body).expect("integrated missing handoff failure must be JSON");
+    assert_provider_error_shape(&json, "auth", "Authentication failed");
+    upstream.assert_async().await;
+}
+
+#[tokio::test]
 async fn standalone_codex_auth_state_succeeds_with_distinct_route_boundary_proof() {
-    let _guard = ENV_LOCK.lock().unwrap();
+    let _guard = ENV_LOCK.lock().await;
     let mut server = Server::new_async().await;
     let access_token = codex_access_token("acct_local_jwt");
     let upstream = server
@@ -1007,13 +1055,15 @@ async fn standalone_codex_auth_state_succeeds_with_distinct_route_boundary_proof
         .await;
 
     let home = TempDir::new().unwrap();
-    write_codex_auth_state(&home, Some("acct_local_explicit"), &access_token);
-
-    let _home = EnvVarGuard::set("HOME", home.path().display().to_string());
+    let auth_path = write_codex_auth_state(&home, Some("acct_local_explicit"), &access_token);
     let _account_id = EnvVarGuard::unset(SUBSTRATE_LLM_BACKEND_AUTH_CLI_CODEX_ACCOUNT_ID);
     let _access_token = EnvVarGuard::unset(SUBSTRATE_LLM_BACKEND_AUTH_CLI_CODEX_ACCESS_TOKEN);
 
-    let harness = build_codex_oauth_provider_harness(&server.url(), "codex-mini-latest");
+    let harness = build_codex_oauth_provider_harness(
+        &server.url(),
+        "codex-mini-latest",
+        CodexAuthSource::StandaloneLocal { path: auth_path },
+    );
     let response = harness
         .invoke_responses(HeaderMap::new(), responses_sync_request())
         .await;
@@ -1027,7 +1077,7 @@ async fn standalone_codex_auth_state_succeeds_with_distinct_route_boundary_proof
 
 #[tokio::test]
 async fn unresolved_codex_identity_fails_before_upstream_for_integrated_and_standalone_modes() {
-    let _guard = ENV_LOCK.lock().unwrap();
+    let _guard = ENV_LOCK.lock().await;
 
     let mut integrated_server = Server::new_async().await;
     let integrated_upstream = integrated_server
@@ -1050,8 +1100,11 @@ async fn unresolved_codex_identity_fails_before_upstream_for_integrated_and_stan
         "not-a-jwt",
     );
 
-    let integrated_harness =
-        build_codex_oauth_provider_harness(&integrated_server.url(), "gpt-5-codex");
+    let integrated_harness = build_codex_oauth_provider_harness(
+        &integrated_server.url(),
+        "gpt-5-codex",
+        CodexAuthSource::Integrated,
+    );
     let integrated_response = integrated_harness
         .invoke_responses(HeaderMap::new(), responses_sync_request())
         .await;
@@ -1079,14 +1132,15 @@ async fn unresolved_codex_identity_fails_before_upstream_for_integrated_and_stan
         .await;
 
     let standalone_home = TempDir::new().unwrap();
-    write_codex_auth_state(&standalone_home, None, "not-a-jwt");
-
-    let _home = EnvVarGuard::set("HOME", standalone_home.path().display().to_string());
+    let auth_path = write_codex_auth_state(&standalone_home, None, "not-a-jwt");
     let _account_id = EnvVarGuard::unset(SUBSTRATE_LLM_BACKEND_AUTH_CLI_CODEX_ACCOUNT_ID);
     let _access_token = EnvVarGuard::unset(SUBSTRATE_LLM_BACKEND_AUTH_CLI_CODEX_ACCESS_TOKEN);
 
-    let standalone_harness =
-        build_codex_oauth_provider_harness(&standalone_server.url(), "gpt-5-codex");
+    let standalone_harness = build_codex_oauth_provider_harness(
+        &standalone_server.url(),
+        "gpt-5-codex",
+        CodexAuthSource::StandaloneLocal { path: auth_path },
+    );
     let standalone_response = standalone_harness
         .invoke_responses(HeaderMap::new(), responses_sync_request())
         .await;

--- a/crates/gateway/tests/openai_shared_parity.rs
+++ b/crates/gateway/tests/openai_shared_parity.rs
@@ -138,6 +138,13 @@ fn make_failure_provider() -> FailingProvider {
     }
 }
 
+fn make_auth_failure_provider() -> FailingProvider {
+    FailingProvider {
+        api_status: 401,
+        message: "unauthorized".to_string(),
+    }
+}
+
 fn reasoning_sync_response() -> GatewayResponse {
     GatewayResponse {
         id: "resp_reasoning_sync".to_string(),
@@ -716,6 +723,40 @@ async fn provider_failure_maps_to_shared_502_envelope() {
         chat_json["error"]["message"],
         responses_json["error"]["message"]
     );
+}
+
+#[tokio::test]
+async fn provider_auth_failure_maps_to_shared_auth_envelope() {
+    let harness = ConformanceHarness::with_registry(
+        "gateway-default",
+        {
+            let mut registry = ProviderRegistry::new();
+            registry
+                .insert_provider_for_tests("test-provider", Box::new(make_auth_failure_provider()));
+            registry
+        },
+        vec![substrate_gateway::cli::ModelMapping {
+            priority: 1,
+            provider: "test-provider".to_string(),
+            actual_model: "primary-actual".to_string(),
+            inject_continuation_prompt: false,
+        }],
+    );
+
+    let response = harness
+        .invoke_responses(HeaderMap::new(), responses_sync_request())
+        .await;
+
+    assert_eq!(response.status(), StatusCode::BAD_GATEWAY);
+
+    let body = response_text(response).await;
+    assert!(
+        !body.contains("unauthorized"),
+        "auth failures should remain redacted"
+    );
+
+    let json: Value = serde_json::from_str(&body).expect("auth failure response body must be JSON");
+    assert_provider_error_shape(&json, "auth", "Authentication failed");
 }
 
 #[tokio::test]

--- a/crates/gateway/tests/openai_shared_parity.rs
+++ b/crates/gateway/tests/openai_shared_parity.rs
@@ -10,7 +10,6 @@ use serde_json::{json, Value};
 use std::env;
 use std::fs;
 use std::sync::Mutex;
-use tempfile::TempDir;
 use substrate_gateway::auth::CodexAuthState;
 use substrate_gateway::core::{
     GatewayRequest, GatewayResponse, GatewayStreamResponse, GatewayUsage,
@@ -19,9 +18,10 @@ use substrate_gateway::models::{ContentBlock, MessageContent};
 use substrate_gateway::providers::error::ProviderError;
 use substrate_gateway::providers::{GatewayProvider, ProviderRegistry};
 use substrate_gateway::server::openai_conformance_test_support::{
-    read_json_fixture, response_text, response_text_response, ConformanceHarness,
-    FixtureNamespace, StubProvider,
+    read_json_fixture, response_text, response_text_response, ConformanceHarness, FixtureNamespace,
+    StubProvider,
 };
+use tempfile::TempDir;
 
 const OPENAI_RESPONSES_TOOL_CHOICE_METADATA_KEY: &str = "openai_responses_tool_choice";
 const SUBSTRATE_LLM_BACKEND_AUTH_CLI_CODEX_ACCOUNT_ID: &str =

--- a/crates/gateway/tests/openai_shared_parity.rs
+++ b/crates/gateway/tests/openai_shared_parity.rs
@@ -393,7 +393,7 @@ async fn responses_direct_fallback_streaming_preserves_sse_contract() {
             "unused",
             "gateway-direct",
         ),
-        read_json_fixture::<Value>(FixtureNamespace::OpenAiResponses, "stream-text.json")
+        read_json_fixture::<Value>(FixtureNamespace::OpenAiResponses, "codex-stream-text.json")
             ["provider_stream_chunks"]
             .as_array()
             .expect("stream fixture chunks")

--- a/crates/gateway/tests/openai_shared_parity.rs
+++ b/crates/gateway/tests/openai_shared_parity.rs
@@ -12,6 +12,8 @@ use substrate_gateway::server::openai_conformance_test_support::{
     read_json_fixture, response_text, ConformanceHarness, FixtureNamespace, StubProvider,
 };
 
+const OPENAI_RESPONSES_TOOL_CHOICE_METADATA_KEY: &str = "openai_responses_tool_choice";
+
 type CapturedRequests = std::sync::Arc<std::sync::Mutex<Vec<GatewayRequest>>>;
 
 #[derive(Debug, Deserialize)]
@@ -231,6 +233,67 @@ async fn model_echo_is_shared_across_endpoints() {
         let responses_requests = responses_requests.lock().unwrap();
         assert_eq!(responses_requests.len(), 1);
         assert_eq!(responses_requests[0].model, "primary-actual");
+    }
+}
+
+#[tokio::test]
+async fn responses_sync_and_stream_requests_preserve_explicit_tool_choice_metadata() {
+    let harness = build_single_provider_harness(StubProvider::new(
+        reasoning_sync_response(),
+        reasoning_stream_chunks(),
+    ));
+
+    let base_request = serde_json::json!({
+        "model": "gateway-default",
+        "input": "hello",
+        "tools": [
+            { "type": "function", "function": { "name": "alpha", "parameters": {"type":"object"} } },
+            { "type": "function", "function": { "name": "beta", "parameters": {"type":"object"} } }
+        ],
+        "tool_choice": { "type": "function", "function": { "name": "beta" } }
+    });
+
+    let sync_response = harness
+        .invoke_responses(HeaderMap::new(), {
+            let mut request = base_request.clone();
+            request["stream"] = serde_json::json!(false);
+            request
+        })
+        .await;
+    assert_eq!(sync_response.status(), StatusCode::OK);
+
+    let stream_response = harness
+        .invoke_responses(HeaderMap::new(), {
+            let mut request = base_request;
+            request["stream"] = serde_json::json!(true);
+            request
+        })
+        .await;
+    assert_eq!(stream_response.status(), StatusCode::OK);
+
+    let captured_requests = harness.captured_requests();
+    let captured_requests = captured_requests.lock().unwrap();
+    assert_eq!(captured_requests.len(), 2);
+
+    for captured in captured_requests.iter() {
+        assert_eq!(
+            captured
+                .metadata
+                .as_ref()
+                .and_then(|metadata| metadata.get(OPENAI_RESPONSES_TOOL_CHOICE_METADATA_KEY)),
+            Some(&serde_json::json!({
+                "type": "function",
+                "function": { "name": "beta" }
+            }))
+        );
+        assert_eq!(captured.tools.as_ref().map(|tools| tools.len()), Some(1));
+        assert_eq!(
+            captured
+                .tools
+                .as_ref()
+                .and_then(|tools| tools[0].name.as_deref()),
+            Some("beta")
+        );
     }
 }
 

--- a/docs/project_management/adrs/draft/ADR-0010-world-backend-contract-and-capability-divergence.md
+++ b/docs/project_management/adrs/draft/ADR-0010-world-backend-contract-and-capability-divergence.md
@@ -15,6 +15,14 @@
 - World architecture + doctor: `docs/WORLD.md`
 - Exit code taxonomy: `docs/project_management/system/standards/shared/EXIT_CODE_TAXONOMY.md`
 - ADR standard/template: `docs/project_management/system/standards/adr/ADR_STANDARD_AND_TEMPLATE.md`
+- Secrets delivery channel rubric: `docs/project_management/system/standards/shared/SECRETS_DELIVERY_CHANNEL_RUBRIC.md`
+- LLM + agent config/policy surface: `docs/project_management/adrs/draft/ADR-0027-llm-and-agent-config-policy-surface.md`
+- Gateway boundary and runtime ownership: `docs/project_management/adrs/draft/ADR-0040-substrate-gateway-boundary-and-runtime-ownership.md`
+- Gateway backend adapter contract: `docs/project_management/adrs/draft/ADR-0041-substrate-gateway-backend-adapter-contract.md`
+- Gateway operator contract: `docs/contracts/substrate-gateway-operator-contract.md`
+- Gateway policy evaluation contract: `docs/contracts/substrate-gateway-policy-evaluation.md`
+- Gateway runtime and platform parity contract: `docs/contracts/substrate-gateway-runtime-parity.md`
+- Phase 8 cross-cutting secret/auth registry: `docs/project_management/packs/PHASE_8_CROSS_CUTTING_DECISION_REGISTRY.md`
 
 ## Executive Summary (Operator)
 
@@ -45,6 +53,7 @@ ADR_BODY_SHA256: <intentionally omitted while Status=Proposed>
 - Designing or implementing a new backend (Docker/Podman, guest-rootfs, etc.).
 - Changing policy schema/keys (unless explicitly required by a later draft).
 - Defining a universal package-manager abstraction (apt/dnf/pacman); this ADR is about backend contracts, not tool provisioning.
+- Redefining the Substrate-owned host-to-world secret delivery contract for in-world gateway or engine auth; that remains governed by ADR-0027, the gateway contracts, the shared secrets-delivery rubric, and the Phase 8 secret/auth registry.
 
 ## User Contract (Authoritative; Proposed)
 
@@ -97,6 +106,7 @@ Each executed command span SHOULD include:
 6) **Provisioning invariants**
 - Runtime sync/install MUST NOT mutate OS packages.
 - OS-level package mutation MUST route through an explicit provisioning entry point (and be unsupported when it would mutate the host OS on platforms where the world backend runs on the host).
+- If a backend participates in host-to-world delivery of auth material for an in-world gateway/engine, it MUST treat that delivery as a Substrate-owned secret-channel concern and stay aligned with the shared FD/pipe-vs-env rubric and the canonical `SUBSTRATE_LLM_BACKEND_AUTH_*` field-name family referenced above.
 
 7) **Validation hooks**
 - Each backend has a smoke script that asserts:
@@ -120,4 +130,3 @@ Each executed command span SHOULD include:
 
 ## Decision Summary
 - None yet (proposal). A Draft should introduce a decision register if multiple non-trivial A/B choices are needed (field naming, minimum capability set, schema versioning strategy).
-


### PR DESCRIPTION
## Summary
**Transport and route behavior**
- Route ChatGPT Codex OAuth traffic through the dedicated `https://chatgpt.com/backend-api/codex/responses` transport for both sync and streaming flows.
- Add Codex semantic sync/stream assembly, route-local request filtering, continuation handling, and public `/v1/responses` normalization for the Codex route.
- Make Codex auth source selection explicit at provider bootstrap and resolve `ChatGPT-Account-ID` from authoritative auth context with bounded JWT fallback and pre-upstream auth failure.

**Conformance and regression coverage**
- Expand `crates/gateway/tests/openai_responses_conformance.rs` and `crates/gateway/tests/openai_shared_parity.rs` to lock sync/stream parity, negative request envelopes, continuation legality, auth-source proofs, and reasoning suppression.
- Add Codex-specific sync/stream/negative fixtures that pin the accepted and rejected request matrix for the route.

**Contracts and planning artifacts**
- Publish the Codex route, auth handoff, and conformance/drift-guard contract docs.
- Land the active pack closeout/governance artifacts for the `chatgpt-codex-oauth-backend-api-responses` seam pack and refresh gateway OAuth/OpenAI compatibility docs.
- Update `CHANGELOG.md` under `Unreleased` to reflect the shipped Codex route work.

## Test Coverage
CODE PATH COVERAGE
===========================
[+] `crates/gateway/src/server/openai_responses.rs`
    - [TESTED] ingress normalization for string input, multimodal messages, tool filtering, explicit tool_choice, negative request rejection, sync mapping, and stream event surface
[+] `crates/gateway/src/providers/openai.rs`
    - [TESTED] Codex responses request serialization, continuation ordering, passthrough control preservation/rejection, minimal header contract, auth-context precedence, sync semantic drain, and streaming semantic assembly
[+] `crates/gateway/src/auth/codex_auth_context.rs`
    - [TESTED] integrated vs standalone mode selection, explicit-over-JWT precedence, missing-handoff failure, and local auth-state resolution
[+] `crates/gateway/src/providers/registry.rs`
    - [GAP] bootstrap env selection for `SUBSTRATE_LLM_GATEWAY_MODE` is exercised indirectly through route tests, but there is no direct unit test for invalid mode values

USER FLOW / ROUTE COVERAGE
===========================
[+] `/v1/responses` sync Codex flow
    - [TESTED] text, tool-call, mixed output, continuation replay, negative request envelopes
[+] `/v1/responses` streaming Codex flow
    - [TESTED] required SSE event order, completed payload parity, reasoning suppression, direct fallback parity
[+] Codex auth boundary
    - [TESTED] integrated handoff success, missing integrated handoff rejection, standalone local auth success, unresolved identity rejection before upstream

---------------------------------
COVERAGE: 11/12 paths tested (92%)
QUALITY: high
GAPS: 1 low-risk bootstrap-mode unit gap
---------------------------------
Tests: 35 -> 35 (+0 new test files)
Coverage gate: PASS (92%).

## Pre-Landing Review
No issues found.

## Design Review
No frontend files changed — design review skipped.

## Eval Results
No prompt-related files changed — evals skipped.

## Scope Drift
Scope Check: CLEAN
Intent: land ChatGPT Codex OAuth backend-api Responses support with explicit auth handoff and route drift guards.
Delivered: provider/runtime support, deterministic conformance coverage, contract docs, and pack closeouts for the Codex route.

## Plan Completion
Plan completion: PASS — the referenced `chatgpt-codex-oauth-backend-api-responses` pack is in closeout state and the delivered diff covers its landed seam obligations.
- [DONE] Seam 1 route contract + stream-native Codex transport (`crates/gateway/src/providers/openai.rs`, `crates/gateway/src/server/openai_responses.rs`, `crates/gateway/tests/openai_responses_conformance.rs`)
- [DONE] Seam 2 auth handoff + account-id provenance (`crates/gateway/src/auth/codex_auth_context.rs`, `crates/gateway/src/providers/registry.rs`, `crates/gateway/tests/openai_shared_parity.rs`)
- [DONE] Seam 3 conformance + maintenance drift guards (`crates/gateway/tests/openai_responses_conformance.rs`, `crates/gateway/tests/openai_shared_parity.rs`, `crates/gateway/docs/contracts/*.md`, pack governance closeouts)

## Verification Results
Skipped: no local dev server was running for browse-based plan verification.

## Test plan
- [x] `cargo test --workspace -- --nocapture`
- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo build --workspace`

Generated with OpenAI Codex

## Documentation
- `CHANGELOG.md`: added `Unreleased` notes for the Codex backend-api Responses transport, auth-context handling, and contract docs.
- `crates/gateway/docs/OAUTH_SETUP.md`: documented the integrated vs standalone Codex auth-handoff boundary and its maintenance evidence anchors.
- `crates/gateway/docs/OAUTH_TESTING.md`: added Codex auth-boundary validation rules and revalidation triggers.
- `crates/gateway/docs/contracts/chatgpt-codex-route-contract.md`: published the canonical route contract for the dedicated Codex transport.
- `crates/gateway/docs/contracts/chatgpt-codex-auth-handoff-contract.md`: published the canonical auth owner-line and fallback contract.
- `crates/gateway/docs/contracts/chatgpt-codex-conformance-and-drift-guard.md`: published the deterministic drift-guard baseline for future maintenance.
- `crates/gateway/docs/project_management/packs/active/chatgpt-codex-oauth-backend-api-responses/*`: landed seam pack closeouts, governance, and maintenance-facing review surfaces.
